### PR TITLE
Update validator shuffling

### DIFF
--- a/eth2_testgen/shuffling/constants.py
+++ b/eth2_testgen/shuffling/constants.py
@@ -1,4 +1,5 @@
-
-SHARD_COUNT = 2**10  # 1024
 EPOCH_LENGTH = 2**6  # 64 slots, 6.4 minutes
+FAR_FUTURE_EPOCH = 2**64 - 1  # uint64 max
+SHARD_COUNT = 2**10  # 1024
 TARGET_COMMITTEE_SIZE = 2**8  # 256 validators
+ENTRY_EXIT_DELAY = 2**2  # 4 epochs

--- a/eth2_testgen/shuffling/enums.py
+++ b/eth2_testgen/shuffling/enums.py
@@ -1,9 +1,0 @@
-from enum import IntEnum
-
-
-class ValidatorStatusCode(IntEnum):
-    PENDING_ACTIVATION = 0
-    ACTIVE = 1
-    ACTIVE_PENDING_EXIT = 2
-    EXITED_WITHOUT_PENALTY = 3
-    EXITED_WITH_PENALTY = 4

--- a/eth2_testgen/shuffling/yaml_objects.py
+++ b/eth2_testgen/shuffling/yaml_objects.py
@@ -3,33 +3,15 @@ from typing import Any
 import yaml
 
 
-class ValidatorRecord(yaml.YAMLObject):
+class Validator(yaml.YAMLObject):
+    """ 
+    A validator stub containing only the fields relevant for get_shuffling()
+    """
     fields = {
-        # Status code
-        'status': 'ValidatorStatusCode',
+        'activation_epoch': 'uint64',
+        'exit_epoch': 'uint64',
         # Extra index field to ease testing/debugging
-        'original_index': 'uint64'
-    }
-
-    def __init__(self, **kwargs):
-        for k in self.fields.keys():
-            setattr(self, k, kwargs.get(k))
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        super().__setattr__(name, value)
-
-    def __getattribute__(self, name: str) -> Any:
-        return super().__getattribute__(name)
-
-
-class ShardCommittee(yaml.YAMLObject):
-    fields = {
-        # Shard number
-        'shard': 'uint64',
-        # Validator indices
-        'committee': ['uint24'],
-        # Total validator count (for proofs of custody)
-        'total_validator_count': 'uint64',
+        'original_index': 'uint64',
     }
 
     def __init__(self, **kwargs):

--- a/test_vectors/test_vector_shuffling.yml
+++ b/test_vectors/test_vector_shuffling.yml
@@ -1,2123 +1,4284 @@
 fork: tchaikovsky
-summary: Test vectors for shuffling a list based upon a seed using `shuffle`
+summary: 'Test vectors for validator shuffling. Note: only relevant validator fields
+  are defined.'
 test_suite: shuffle
 title: Shuffling Algorithm Tests
 version: 1.0
 test_cases:
 - input:
-    crosslinking_start_shard: 210
-    validators_status: [2, 4, 0, 0, 2, 2, 4, 2, 3, 1, 0, 3, 3, 4, 4, 4, 1, 1, 1, 1,
-      3, 2, 3, 0, 2, 4, 0, 2, 4, 0, 0, 4, 2, 1, 4, 1, 4, 2, 2, 1, 2, 4, 0, 4, 0, 3,
-      0, 4, 4, 0, 0, 1, 3, 3, 0, 4, 3, 1, 1, 3, 1, 0, 0, 1, 0, 0, 4, 1, 2, 0, 1, 4,
-      2, 1, 1, 4, 1, 1, 1, 1, 0, 4, 4, 0, 1, 3, 4, 2, 0, 1, 4, 3, 1, 2, 4, 2, 2, 2,
-      3, 3, 3, 0, 2, 0, 4, 1, 1, 3, 0, 3, 1, 3, 4, 3, 3, 4, 0, 1, 0, 3, 3, 1, 4, 2,
-      0, 3, 2, 3, 0, 4, 3, 1, 3, 3, 4, 3, 0, 0, 1, 0, 2, 4, 1, 3, 1, 3, 2, 4, 2, 2,
-      0, 3, 2, 3, 1, 3, 0, 2, 1, 3, 2, 2, 1, 3, 0, 2, 1, 3, 2, 2, 2, 0, 0, 0, 3, 4,
-      1, 4, 4, 3, 3, 0, 1, 2, 4, 1, 4, 0, 0, 4, 3, 2, 4, 3, 1, 2, 0, 4, 4, 2, 0, 4,
-      4, 4, 4, 0, 1, 4, 4, 3, 0, 3, 2, 1, 4, 3, 0, 3, 0, 3, 1, 3, 3, 2, 3, 2, 2, 2,
-      1, 0, 4, 2, 0, 4, 2, 2, 0, 1, 0, 0, 2, 0, 3, 3, 2, 4, 0, 3, 1, 0, 3, 4, 2, 4,
-      0, 1, 4, 1, 0, 0, 4, 3, 3, 1, 1, 4, 1, 3, 1, 0, 4, 3, 3, 0, 2, 1, 3, 4, 1, 3,
-      3, 3, 0, 4, 2, 3, 0, 0, 0, 1, 4, 3, 1, 4, 2, 0, 4, 2, 3, 0, 1, 2, 0, 4, 0, 4,
-      4, 2, 1, 3, 4, 3, 2, 3, 3, 4, 3, 2, 2, 1, 3, 0, 3, 2, 1, 0, 1, 3, 2, 0, 0, 0,
-      1, 1, 2, 2, 0, 3, 1, 0, 3, 2, 0, 0, 2, 3, 0, 0, 4, 4, 2, 0, 1, 1, 3, 0, 1, 0,
-      1, 1, 3, 4, 0, 0, 3, 4, 4, 4, 0, 2, 4, 4, 1, 0, 2, 2, 3, 4, 4, 0, 1, 3, 2, 4,
-      0, 1, 2, 1, 3, 3, 0, 3, 4, 1, 3, 1, 0, 1, 0, 4, 4, 3, 4, 1, 0, 3, 1, 3]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 803, exit_epoch: 934, original_index: 0}
+    - {activation_epoch: 956, exit_epoch: 4446, original_index: 1}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 2}
+    - {activation_epoch: 980, exit_epoch: 4107, original_index: 3}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 4}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 5}
+    - {activation_epoch: 1019, exit_epoch: 2522, original_index: 6}
+    - {activation_epoch: 1051, exit_epoch: 18446744073709551615, original_index: 7}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 8}
+    - {activation_epoch: 941, exit_epoch: 1584, original_index: 9}
+    - {activation_epoch: 325, exit_epoch: 974, original_index: 10}
+    - {activation_epoch: 524, exit_epoch: 1023, original_index: 11}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 12}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 13}
+    - {activation_epoch: 1015, exit_epoch: 3033, original_index: 14}
+    - {activation_epoch: 405, exit_epoch: 1013, original_index: 15}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 16}
+    - {activation_epoch: 88, exit_epoch: 1006, original_index: 17}
+    - {activation_epoch: 234, exit_epoch: 981, original_index: 18}
+    - {activation_epoch: 985, exit_epoch: 18446744073709551615, original_index: 19}
+    - {activation_epoch: 1020, exit_epoch: 4162, original_index: 20}
+    - {activation_epoch: 420, exit_epoch: 1043, original_index: 21}
+    - {activation_epoch: 978, exit_epoch: 1158, original_index: 22}
+    - {activation_epoch: 138, exit_epoch: 1024, original_index: 23}
+    - {activation_epoch: 384, exit_epoch: 1005, original_index: 24}
+    - {activation_epoch: 440, exit_epoch: 996, original_index: 25}
+    - {activation_epoch: 1024, exit_epoch: 4401, original_index: 26}
+    - {activation_epoch: 1025, exit_epoch: 18446744073709551615, original_index: 27}
+    - {activation_epoch: 999, exit_epoch: 2879, original_index: 28}
+    - {activation_epoch: 1004, exit_epoch: 1663, original_index: 29}
+    - {activation_epoch: 981, exit_epoch: 3854, original_index: 30}
+    - {activation_epoch: 739, exit_epoch: 1065, original_index: 31}
+    - {activation_epoch: 1014, exit_epoch: 18446744073709551615, original_index: 32}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 33}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 34}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 35}
+    - {activation_epoch: 43, exit_epoch: 1017, original_index: 36}
+    - {activation_epoch: 1018, exit_epoch: 18446744073709551615, original_index: 37}
+    - {activation_epoch: 971, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 259, exit_epoch: 929, original_index: 39}
+    - {activation_epoch: 823, exit_epoch: 965, original_index: 40}
+    - {activation_epoch: 969, exit_epoch: 1004, original_index: 41}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 42}
+    - {activation_epoch: 904, exit_epoch: 1046, original_index: 43}
+    - {activation_epoch: 1036, exit_epoch: 3792, original_index: 44}
+    - {activation_epoch: 699, exit_epoch: 1013, original_index: 45}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 46}
+    - {activation_epoch: 161, exit_epoch: 989, original_index: 47}
+    - {activation_epoch: 337, exit_epoch: 988, original_index: 48}
+    - {activation_epoch: 161, exit_epoch: 1038, original_index: 49}
+    - {activation_epoch: 54, exit_epoch: 982, original_index: 50}
+    - {activation_epoch: 1065, exit_epoch: 18446744073709551615, original_index: 51}
+    - {activation_epoch: 956, exit_epoch: 18446744073709551615, original_index: 52}
+    - {activation_epoch: 354, exit_epoch: 1061, original_index: 53}
+    - {activation_epoch: 943, exit_epoch: 18446744073709551615, original_index: 54}
+    - {activation_epoch: 528, exit_epoch: 989, original_index: 55}
+    - {activation_epoch: 410, exit_epoch: 1037, original_index: 56}
+    - {activation_epoch: 952, exit_epoch: 1315, original_index: 57}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 58}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 59}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 60}
+    - {activation_epoch: 67, exit_epoch: 1003, original_index: 61}
+    - {activation_epoch: 954, exit_epoch: 3688, original_index: 62}
+    - {activation_epoch: 668, exit_epoch: 973, original_index: 63}
+    - {activation_epoch: 1054, exit_epoch: 18446744073709551615, original_index: 64}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 65}
+    - {activation_epoch: 183, exit_epoch: 1018, original_index: 66}
+    - {activation_epoch: 974, exit_epoch: 18446744073709551615, original_index: 67}
+    - {activation_epoch: 994, exit_epoch: 1230, original_index: 68}
+    - {activation_epoch: 971, exit_epoch: 1004, original_index: 69}
+    - {activation_epoch: 991, exit_epoch: 18446744073709551615, original_index: 70}
+    - {activation_epoch: 966, exit_epoch: 4828, original_index: 71}
+    - {activation_epoch: 964, exit_epoch: 2250, original_index: 72}
+    - {activation_epoch: 539, exit_epoch: 1059, original_index: 73}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 74}
+    - {activation_epoch: 958, exit_epoch: 1013, original_index: 75}
+    - {activation_epoch: 667, exit_epoch: 979, original_index: 76}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 77}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 78}
+    - {activation_epoch: 1039, exit_epoch: 18446744073709551615, original_index: 79}
+    - {activation_epoch: 951, exit_epoch: 18446744073709551615, original_index: 80}
+    - {activation_epoch: 12, exit_epoch: 1010, original_index: 81}
+    - {activation_epoch: 944, exit_epoch: 2129, original_index: 82}
+    - {activation_epoch: 157, exit_epoch: 990, original_index: 83}
+    - {activation_epoch: 1010, exit_epoch: 3719, original_index: 84}
+    - {activation_epoch: 348, exit_epoch: 1039, original_index: 85}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 86}
+    - {activation_epoch: 440, exit_epoch: 976, original_index: 87}
+    - {activation_epoch: 696, exit_epoch: 964, original_index: 88}
+    - {activation_epoch: 1049, exit_epoch: 18446744073709551615, original_index: 89}
+    - {activation_epoch: 1019, exit_epoch: 18446744073709551615, original_index: 90}
+    - {activation_epoch: 1008, exit_epoch: 3862, original_index: 91}
+    - {activation_epoch: 984, exit_epoch: 4679, original_index: 92}
+    - {activation_epoch: 949, exit_epoch: 18446744073709551615, original_index: 93}
+    - {activation_epoch: 1048, exit_epoch: 3395, original_index: 94}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 95}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 96}
+    - {activation_epoch: 781, exit_epoch: 1039, original_index: 97}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 98}
+    - {activation_epoch: 991, exit_epoch: 4567, original_index: 99}
+    - {activation_epoch: 955, exit_epoch: 18446744073709551615, original_index: 100}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 101}
+    - {activation_epoch: 25, exit_epoch: 950, original_index: 102}
+    - {activation_epoch: 1025, exit_epoch: 3315, original_index: 103}
+    - {activation_epoch: 975, exit_epoch: 18446744073709551615, original_index: 104}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 105}
+    - {activation_epoch: 740, exit_epoch: 987, original_index: 106}
+    - {activation_epoch: 1056, exit_epoch: 2489, original_index: 107}
+    - {activation_epoch: 974, exit_epoch: 1039, original_index: 108}
+    - {activation_epoch: 178, exit_epoch: 1000, original_index: 109}
+    - {activation_epoch: 712, exit_epoch: 1018, original_index: 110}
+    - {activation_epoch: 224, exit_epoch: 954, original_index: 111}
+    - {activation_epoch: 397, exit_epoch: 1003, original_index: 112}
+    - {activation_epoch: 938, exit_epoch: 18446744073709551615, original_index: 113}
+    - {activation_epoch: 635, exit_epoch: 1019, original_index: 114}
+    - {activation_epoch: 395, exit_epoch: 999, original_index: 115}
+    - {activation_epoch: 927, exit_epoch: 2962, original_index: 116}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 117}
+    - {activation_epoch: 1049, exit_epoch: 18446744073709551615, original_index: 118}
+    - {activation_epoch: 981, exit_epoch: 2552, original_index: 119}
+    - {activation_epoch: 999, exit_epoch: 4687, original_index: 120}
+    - {activation_epoch: 982, exit_epoch: 4630, original_index: 121}
+    - {activation_epoch: 221, exit_epoch: 1017, original_index: 122}
+    - {activation_epoch: 1038, exit_epoch: 18446744073709551615, original_index: 123}
+    - {activation_epoch: 954, exit_epoch: 1836, original_index: 124}
+    - {activation_epoch: 970, exit_epoch: 18446744073709551615, original_index: 125}
+    - {activation_epoch: 798, exit_epoch: 1009, original_index: 126}
+    - {activation_epoch: 988, exit_epoch: 1779, original_index: 127}
+    - {activation_epoch: 388, exit_epoch: 1024, original_index: 128}
+    - {activation_epoch: 406, exit_epoch: 976, original_index: 129}
+    - {activation_epoch: 977, exit_epoch: 1199, original_index: 130}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 131}
+    - {activation_epoch: 513, exit_epoch: 935, original_index: 132}
+    - {activation_epoch: 905, exit_epoch: 1005, original_index: 133}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 134}
+    - {activation_epoch: 386, exit_epoch: 1045, original_index: 135}
+    - {activation_epoch: 156, exit_epoch: 948, original_index: 136}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 137}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 138}
+    - {activation_epoch: 345, exit_epoch: 1023, original_index: 139}
+    - {activation_epoch: 1008, exit_epoch: 1947, original_index: 140}
+    - {activation_epoch: 107, exit_epoch: 1009, original_index: 141}
+    - {activation_epoch: 1031, exit_epoch: 18446744073709551615, original_index: 142}
+    - {activation_epoch: 732, exit_epoch: 989, original_index: 143}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 144}
+    - {activation_epoch: 1048, exit_epoch: 18446744073709551615, original_index: 145}
+    - {activation_epoch: 856, exit_epoch: 1069, original_index: 146}
+    - {activation_epoch: 816, exit_epoch: 1041, original_index: 147}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 148}
+    - {activation_epoch: 825, exit_epoch: 981, original_index: 149}
+    - {activation_epoch: 728, exit_epoch: 1015, original_index: 150}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 151}
+    - {activation_epoch: 57, exit_epoch: 1061, original_index: 152}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 153}
+    - {activation_epoch: 429, exit_epoch: 1002, original_index: 154}
+    - {activation_epoch: 194, exit_epoch: 1043, original_index: 155}
+    - {activation_epoch: 1023, exit_epoch: 4695, original_index: 156}
+    - {activation_epoch: 1052, exit_epoch: 18446744073709551615, original_index: 157}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 158}
+    - {activation_epoch: 257, exit_epoch: 960, original_index: 159}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 160}
+    - {activation_epoch: 274, exit_epoch: 950, original_index: 161}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 162}
+    - {activation_epoch: 975, exit_epoch: 18446744073709551615, original_index: 163}
+    - {activation_epoch: 1043, exit_epoch: 18446744073709551615, original_index: 164}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 165}
+    - {activation_epoch: 737, exit_epoch: 966, original_index: 166}
+    - {activation_epoch: 16, exit_epoch: 961, original_index: 167}
+    - {activation_epoch: 150, exit_epoch: 1008, original_index: 168}
+    - {activation_epoch: 710, exit_epoch: 1049, original_index: 169}
+    - {activation_epoch: 910, exit_epoch: 1029, original_index: 170}
+    - {activation_epoch: 980, exit_epoch: 1024, original_index: 171}
+    - {activation_epoch: 437, exit_epoch: 996, original_index: 172}
+    - {activation_epoch: 1027, exit_epoch: 18446744073709551615, original_index: 173}
+    - {activation_epoch: 805, exit_epoch: 981, original_index: 174}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 175}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 176}
+    - {activation_epoch: 54, exit_epoch: 1033, original_index: 177}
+    - {activation_epoch: 811, exit_epoch: 1037, original_index: 178}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 179}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 180}
+    - {activation_epoch: 1020, exit_epoch: 2112, original_index: 181}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 182}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 183}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 184}
+    - {activation_epoch: 895, exit_epoch: 949, original_index: 185}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 186}
+    - {activation_epoch: 112, exit_epoch: 1007, original_index: 187}
+    - {activation_epoch: 779, exit_epoch: 1027, original_index: 188}
+    - {activation_epoch: 1036, exit_epoch: 18446744073709551615, original_index: 189}
+    - {activation_epoch: 948, exit_epoch: 18446744073709551615, original_index: 190}
+    - {activation_epoch: 997, exit_epoch: 3234, original_index: 191}
+    - {activation_epoch: 1002, exit_epoch: 2378, original_index: 192}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 193}
+    - {activation_epoch: 449, exit_epoch: 987, original_index: 194}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 195}
+    - {activation_epoch: 349, exit_epoch: 1025, original_index: 196}
+    - {activation_epoch: 994, exit_epoch: 1706, original_index: 197}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 198}
+    - {activation_epoch: 1004, exit_epoch: 3217, original_index: 199}
+    - {activation_epoch: 1036, exit_epoch: 18446744073709551615, original_index: 200}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 201}
+    - {activation_epoch: 999, exit_epoch: 1935, original_index: 202}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 203}
+    - {activation_epoch: 649, exit_epoch: 963, original_index: 204}
+    - {activation_epoch: 1054, exit_epoch: 4345, original_index: 205}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 206}
+    - {activation_epoch: 996, exit_epoch: 18446744073709551615, original_index: 207}
+    - {activation_epoch: 1037, exit_epoch: 3849, original_index: 208}
+    - {activation_epoch: 135, exit_epoch: 966, original_index: 209}
+    - {activation_epoch: 962, exit_epoch: 2935, original_index: 210}
+    - {activation_epoch: 560, exit_epoch: 980, original_index: 211}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 212}
+    - {activation_epoch: 500, exit_epoch: 1020, original_index: 213}
+    - {activation_epoch: 37, exit_epoch: 1025, original_index: 214}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 215}
+    - {activation_epoch: 302, exit_epoch: 1021, original_index: 216}
+    - {activation_epoch: 981, exit_epoch: 18446744073709551615, original_index: 217}
+    - {activation_epoch: 378, exit_epoch: 965, original_index: 218}
+    - {activation_epoch: 952, exit_epoch: 1027, original_index: 219}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 220}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 221}
+    - {activation_epoch: 400, exit_epoch: 1071, original_index: 222}
+    - {activation_epoch: 988, exit_epoch: 1049, original_index: 223}
+    - {activation_epoch: 471, exit_epoch: 949, original_index: 224}
+    - {activation_epoch: 1045, exit_epoch: 1285, original_index: 225}
+    - {activation_epoch: 1019, exit_epoch: 18446744073709551615, original_index: 226}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 227}
+    - {activation_epoch: 636, exit_epoch: 976, original_index: 228}
+    - {activation_epoch: 931, exit_epoch: 18446744073709551615, original_index: 229}
+    - {activation_epoch: 343, exit_epoch: 1004, original_index: 230}
+    - {activation_epoch: 1032, exit_epoch: 3213, original_index: 231}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 232}
+    - {activation_epoch: 349, exit_epoch: 975, original_index: 233}
+    - {activation_epoch: 172, exit_epoch: 1036, original_index: 234}
+    - {activation_epoch: 493, exit_epoch: 1003, original_index: 235}
+    - {activation_epoch: 1037, exit_epoch: 1948, original_index: 236}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 237}
+    - {activation_epoch: 652, exit_epoch: 1002, original_index: 238}
+    - {activation_epoch: 363, exit_epoch: 964, original_index: 239}
+    - {activation_epoch: 431, exit_epoch: 953, original_index: 240}
+    - {activation_epoch: 994, exit_epoch: 1780, original_index: 241}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 242}
+    - {activation_epoch: 322, exit_epoch: 950, original_index: 243}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 244}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 245}
+    - {activation_epoch: 1010, exit_epoch: 3053, original_index: 246}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 247}
+    - {activation_epoch: 74, exit_epoch: 1027, original_index: 248}
+    - {activation_epoch: 684, exit_epoch: 996, original_index: 249}
+    - {activation_epoch: 166, exit_epoch: 947, original_index: 250}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 251}
+    - {activation_epoch: 104, exit_epoch: 1023, original_index: 252}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 253}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 254}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 255}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 256}
+    - {activation_epoch: 1020, exit_epoch: 18446744073709551615, original_index: 257}
+    - {activation_epoch: 282, exit_epoch: 949, original_index: 258}
+    - {activation_epoch: 506, exit_epoch: 1012, original_index: 259}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 260}
+    - {activation_epoch: 1029, exit_epoch: 1916, original_index: 261}
+    - {activation_epoch: 1010, exit_epoch: 1135, original_index: 262}
+    - {activation_epoch: 377, exit_epoch: 1025, original_index: 263}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 264}
+    - {activation_epoch: 1039, exit_epoch: 2094, original_index: 265}
+    - {activation_epoch: 949, exit_epoch: 18446744073709551615, original_index: 266}
+    - {activation_epoch: 972, exit_epoch: 1817, original_index: 267}
+    - {activation_epoch: 517, exit_epoch: 949, original_index: 268}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 269}
+    - {activation_epoch: 779, exit_epoch: 1042, original_index: 270}
+    - {activation_epoch: 1014, exit_epoch: 3474, original_index: 271}
+    - {activation_epoch: 249, exit_epoch: 1007, original_index: 272}
+    - {activation_epoch: 2, exit_epoch: 1002, original_index: 273}
+    - {activation_epoch: 147, exit_epoch: 1024, original_index: 274}
+    - {activation_epoch: 927, exit_epoch: 18446744073709551615, original_index: 275}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 276}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 277}
+    - {activation_epoch: 855, exit_epoch: 1013, original_index: 278}
+    - {activation_epoch: 1091, exit_epoch: 4341, original_index: 279}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 280}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 281}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 282}
+    - {activation_epoch: 703, exit_epoch: 1013, original_index: 283}
+    - {activation_epoch: 1061, exit_epoch: 2183, original_index: 284}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 285}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 286}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 287}
+    - {activation_epoch: 1048, exit_epoch: 18446744073709551615, original_index: 288}
+    - {activation_epoch: 353, exit_epoch: 1039, original_index: 289}
+    - {activation_epoch: 1020, exit_epoch: 2140, original_index: 290}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 291}
+    - {activation_epoch: 975, exit_epoch: 991, original_index: 292}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 293}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 294}
+    - {activation_epoch: 963, exit_epoch: 4782, original_index: 295}
+    - {activation_epoch: 228, exit_epoch: 1012, original_index: 296}
+    - {activation_epoch: 991, exit_epoch: 1139, original_index: 297}
+    - {activation_epoch: 443, exit_epoch: 1034, original_index: 298}
+    - {activation_epoch: 943, exit_epoch: 18446744073709551615, original_index: 299}
+    - {activation_epoch: 928, exit_epoch: 18446744073709551615, original_index: 300}
+    - {activation_epoch: 1057, exit_epoch: 18446744073709551615, original_index: 301}
+    - {activation_epoch: 126, exit_epoch: 1008, original_index: 302}
+    - {activation_epoch: 1022, exit_epoch: 18446744073709551615, original_index: 303}
+    - {activation_epoch: 550, exit_epoch: 1010, original_index: 304}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 305}
+    - {activation_epoch: 912, exit_epoch: 1030, original_index: 306}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 307}
+    - {activation_epoch: 330, exit_epoch: 1024, original_index: 308}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 309}
+    - {activation_epoch: 975, exit_epoch: 4814, original_index: 310}
+    - {activation_epoch: 975, exit_epoch: 18446744073709551615, original_index: 311}
+    - {activation_epoch: 958, exit_epoch: 3809, original_index: 312}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 313}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 314}
+    - {activation_epoch: 8, exit_epoch: 1015, original_index: 315}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 316}
+    - {activation_epoch: 950, exit_epoch: 18446744073709551615, original_index: 317}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 318}
+    - {activation_epoch: 43, exit_epoch: 979, original_index: 319}
+    - {activation_epoch: 572, exit_epoch: 968, original_index: 320}
+    - {activation_epoch: 118, exit_epoch: 1007, original_index: 321}
+    - {activation_epoch: 685, exit_epoch: 1017, original_index: 322}
+    - {activation_epoch: 242, exit_epoch: 1035, original_index: 323}
+    - {activation_epoch: 75, exit_epoch: 1001, original_index: 324}
+    - {activation_epoch: 1033, exit_epoch: 18446744073709551615, original_index: 325}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 326}
+    - {activation_epoch: 976, exit_epoch: 18446744073709551615, original_index: 327}
+    - {activation_epoch: 979, exit_epoch: 3215, original_index: 328}
+    - {activation_epoch: 953, exit_epoch: 4211, original_index: 329}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 330}
+    - {activation_epoch: 878, exit_epoch: 1058, original_index: 331}
+    - {activation_epoch: 723, exit_epoch: 967, original_index: 332}
+    - {activation_epoch: 1017, exit_epoch: 18446744073709551615, original_index: 333}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 334}
+    - {activation_epoch: 175, exit_epoch: 982, original_index: 335}
+    - {activation_epoch: 1038, exit_epoch: 18446744073709551615, original_index: 336}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 337}
+    - {activation_epoch: 1050, exit_epoch: 18446744073709551615, original_index: 338}
+    - {activation_epoch: 1013, exit_epoch: 3241, original_index: 339}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 340}
+    - {activation_epoch: 965, exit_epoch: 3714, original_index: 341}
+    - {activation_epoch: 244, exit_epoch: 948, original_index: 342}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 343}
+    - {activation_epoch: 1040, exit_epoch: 2895, original_index: 344}
+    - {activation_epoch: 521, exit_epoch: 956, original_index: 345}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 346}
+    - {activation_epoch: 717, exit_epoch: 968, original_index: 347}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 348}
+    - {activation_epoch: 596, exit_epoch: 1021, original_index: 349}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 350}
+    - {activation_epoch: 966, exit_epoch: 1259, original_index: 351}
+    - {activation_epoch: 909, exit_epoch: 4648, original_index: 352}
+    - {activation_epoch: 1031, exit_epoch: 18446744073709551615, original_index: 353}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 354}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 355}
+    - {activation_epoch: 598, exit_epoch: 1034, original_index: 356}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 357}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 358}
+    - {activation_epoch: 991, exit_epoch: 1969, original_index: 359}
+    - {activation_epoch: 1014, exit_epoch: 3215, original_index: 360}
+    - {activation_epoch: 646, exit_epoch: 1024, original_index: 361}
+    - {activation_epoch: 80, exit_epoch: 994, original_index: 362}
+    - {activation_epoch: 1034, exit_epoch: 18446744073709551615, original_index: 363}
+    - {activation_epoch: 965, exit_epoch: 1725, original_index: 364}
+    - {activation_epoch: 114, exit_epoch: 1047, original_index: 365}
+    - {activation_epoch: 1027, exit_epoch: 3300, original_index: 366}
+    - {activation_epoch: 1014, exit_epoch: 2257, original_index: 367}
+    - {activation_epoch: 744, exit_epoch: 1003, original_index: 368}
+    - {activation_epoch: 1014, exit_epoch: 2621, original_index: 369}
+    - {activation_epoch: 285, exit_epoch: 943, original_index: 370}
+    - {activation_epoch: 165, exit_epoch: 1021, original_index: 371}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 372}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 373}
+    - {activation_epoch: 962, exit_epoch: 4619, original_index: 374}
+    - {activation_epoch: 975, exit_epoch: 1125, original_index: 375}
+    - {activation_epoch: 201, exit_epoch: 1014, original_index: 376}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 377}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 378}
+    - {activation_epoch: 1030, exit_epoch: 3378, original_index: 379}
+    - {activation_epoch: 1002, exit_epoch: 4643, original_index: 380}
+    - {activation_epoch: 981, exit_epoch: 1296, original_index: 381}
+    - {activation_epoch: 444, exit_epoch: 982, original_index: 382}
+    - {activation_epoch: 430, exit_epoch: 967, original_index: 383}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 384}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 385}
+    - {activation_epoch: 943, exit_epoch: 1000, original_index: 386}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 387}
+    - {activation_epoch: 91, exit_epoch: 1015, original_index: 388}
+    - {activation_epoch: 629, exit_epoch: 1010, original_index: 389}
+    - {activation_epoch: 1021, exit_epoch: 2138, original_index: 390}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 391}
+    - {activation_epoch: 1003, exit_epoch: 3772, original_index: 392}
+    - {activation_epoch: 666, exit_epoch: 1029, original_index: 393}
+    - {activation_epoch: 954, exit_epoch: 3189, original_index: 394}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 395}
+    - {activation_epoch: 995, exit_epoch: 4495, original_index: 396}
+    - {activation_epoch: 974, exit_epoch: 18446744073709551615, original_index: 397}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 398}
+    - {activation_epoch: 1015, exit_epoch: 4990, original_index: 399}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 400}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 401}
+    - {activation_epoch: 778, exit_epoch: 1053, original_index: 402}
+    - {activation_epoch: 503, exit_epoch: 973, original_index: 403}
+    - {activation_epoch: 467, exit_epoch: 1038, original_index: 404}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 405}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 406}
+    - {activation_epoch: 982, exit_epoch: 3570, original_index: 407}
   output:
-  - - committee: [170, 97]
-      shard: 210
-      total_validator_count: 148
-  - - committee: [77, 105]
-      shard: 211
-      total_validator_count: 148
-  - - committee: [317, 183]
-      shard: 212
-      total_validator_count: 148
-  - - committee: [92, 5, 165]
-      shard: 213
-      total_validator_count: 148
-  - - committee: [123, 67]
-      shard: 214
-      total_validator_count: 148
-  - - committee: [138, 297]
-      shard: 215
-      total_validator_count: 148
-  - - committee: [19, 212, 110]
-      shard: 216
-      total_validator_count: 148
-  - - committee: [199, 326]
-      shard: 217
-      total_validator_count: 148
-  - - committee: [63, 395]
-      shard: 218
-      total_validator_count: 148
-  - - committee: [289, 0, 148]
-      shard: 219
-      total_validator_count: 148
-  - - committee: [300, 268]
-      shard: 220
-      total_validator_count: 148
-  - - committee: [350, 274]
-      shard: 221
-      total_validator_count: 148
-  - - committee: [338, 257, 319]
-      shard: 222
-      total_validator_count: 148
-  - - committee: [213, 226]
-      shard: 223
-      total_validator_count: 148
-  - - committee: [162, 240]
-      shard: 224
-      total_validator_count: 148
-  - - committee: [284, 39, 185]
-      shard: 225
-      total_validator_count: 148
-  - - committee: [17, 60]
-      shard: 226
-      total_validator_count: 148
-  - - committee: [318, 194]
-      shard: 227
-      total_validator_count: 148
-  - - committee: [166, 380]
-      shard: 228
-      total_validator_count: 148
-  - - committee: [168, 334, 78]
-      shard: 229
-      total_validator_count: 148
-  - - committee: [35, 76]
-      shard: 230
-      total_validator_count: 148
-  - - committee: [144, 406]
-      shard: 231
-      total_validator_count: 148
-  - - committee: [352, 152, 385]
-      shard: 232
-      total_validator_count: 148
-  - - committee: [121, 154]
-      shard: 233
-      total_validator_count: 148
-  - - committee: [356, 21]
-      shard: 234
-      total_validator_count: 148
-  - - committee: [292, 58, 96]
-      shard: 235
-      total_validator_count: 148
-  - - committee: [176, 223]
-      shard: 236
-      total_validator_count: 148
-  - - committee: [301, 68]
-      shard: 237
-      total_validator_count: 148
-  - - committee: [161, 220, 146]
-      shard: 238
-      total_validator_count: 148
-  - - committee: [195, 328]
-      shard: 239
-      total_validator_count: 148
-  - - committee: [89, 7]
-      shard: 240
-      total_validator_count: 148
-  - - committee: [38, 308, 51]
-      shard: 241
-      total_validator_count: 148
-  - - committee: [102, 16]
-      shard: 242
-      total_validator_count: 148
-  - - committee: [252, 33]
-      shard: 243
-      total_validator_count: 148
-  - - committee: [372, 294]
-      shard: 244
-      total_validator_count: 148
-  - - committee: [332, 235, 358]
-      shard: 245
-      total_validator_count: 148
-  - - committee: [403, 18]
-      shard: 246
-      total_validator_count: 148
-  - - committee: [353, 263]
-      shard: 247
-      total_validator_count: 148
-  - - committee: [169, 57, 158]
-      shard: 248
-      total_validator_count: 148
-  - - committee: [117, 74]
-      shard: 249
-      total_validator_count: 148
-  - - committee: [142, 333]
-      shard: 250
-      total_validator_count: 148
-  - - committee: [95, 24, 335]
-      shard: 251
-      total_validator_count: 148
-  - - committee: [266, 70]
-      shard: 252
-      total_validator_count: 148
-  - - committee: [27, 369]
-      shard: 253
-      total_validator_count: 148
-  - - committee: [79, 248, 397]
-      shard: 254
-      total_validator_count: 148
-  - - committee: [72, 140]
-      shard: 255
-      total_validator_count: 148
-  - - committee: [264, 157]
-      shard: 256
-      total_validator_count: 148
-  - - committee: [227, 231, 393]
-      shard: 257
-      total_validator_count: 148
-  - - committee: [131, 73]
-      shard: 258
-      total_validator_count: 148
-  - - committee: [375, 255]
-      shard: 259
-      total_validator_count: 148
-  - - committee: [382, 182]
-      shard: 260
-      total_validator_count: 148
-  - - committee: [32, 374, 206]
-      shard: 261
-      total_validator_count: 148
-  - - committee: [4, 341]
-      shard: 262
-      total_validator_count: 148
-  - - committee: [359, 307]
-      shard: 263
-      total_validator_count: 148
-  - - committee: [312, 237, 160]
-      shard: 264
-      total_validator_count: 148
-  - - committee: [9, 225]
-      shard: 265
-      total_validator_count: 148
-  - - committee: [37, 191]
-      shard: 266
-      total_validator_count: 148
-  - - committee: [234, 387, 386]
-      shard: 267
-      total_validator_count: 148
-  - - committee: [228, 40]
-      shard: 268
-      total_validator_count: 148
-  - - committee: [106, 93]
-      shard: 269
-      total_validator_count: 148
-  - - committee: [324, 275, 344]
-      shard: 270
-      total_validator_count: 148
-  - - committee: [149, 126]
-      shard: 271
-      total_validator_count: 148
-  - - committee: [84, 278]
-      shard: 272
-      total_validator_count: 148
-  - - committee: [87, 244, 323]
-      shard: 273
-      total_validator_count: 148
+  - [31, 223]
+  - [30, 1, 331]
+  - [404, 295, 122]
+  - [343, 393, 147]
+  - [341, 190]
+  - [177, 278, 52]
+  - [196, 216, 53]
+  - [322, 232, 104]
+  - [191, 289]
+  - [241, 70, 234]
+  - [24, 58, 150]
+  - [324, 273, 100]
+  - [97, 407]
+  - [33, 349, 371]
+  - [235, 184, 96]
+  - [310, 15, 252]
+  - [85, 21]
+  - [210, 266, 298]
+  - [300, 121, 394]
+  - [54, 286, 126]
+  - [113, 306]
+  - [175, 127, 402]
+  - [304, 28, 321]
+  - [57, 168, 334]
+  - [219, 71]
+  - [389, 3, 202]
+  - [135, 396, 280]
+  - [270, 81, 49]
+  - [302, 222]
+  - [229, 381, 75]
+  - [110, 61, 67]
+  - [178, 242, 9]
+  - [120, 272]
+  - [356, 375, 317]
+  - [38, 238, 364]
+  - [62, 146, 169]
+  - [93, 248]
+  - [36, 163, 259]
+  - [368, 312, 327]
+  - [217, 376, 315]
+  - [114, 187]
+  - [213, 124, 133]
+  - [43, 274, 352]
+  - [125, 45, 297]
+  - [66, 73]
+  - [80, 263, 328]
+  - [329, 374, 139]
+  - [351, 308, 267]
+  - [197, 170]
+  - [214, 19, 311]
+  - [69, 323, 68]
+  - [283, 99, 357]
+  - [207, 17]
+  - [141, 154, 119]
+  - [11, 152, 13]
+  - [41, 108, 340]
+  - [56, 171]
+  - [112, 128, 72]
+  - [388, 92, 296]
+  - [23, 22, 155]
+  - [365, 230]
+  - [397, 275, 130]
+  - [188, 116, 82]
+  - [359, 299, 361]
   seed: '0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d'
 - input:
-    crosslinking_start_shard: 102
-    validators_status: [3, 2, 4, 4, 3, 1, 0, 4, 3, 3, 3, 3, 4, 2, 1, 1, 3, 4, 1, 1,
-      3, 0, 4, 0, 2, 4, 1, 1, 3, 4, 1, 0, 2, 3, 4, 2, 2, 4, 1, 4, 4, 2, 0, 2, 4, 0,
-      1, 4, 0, 0, 1, 3, 0, 3, 0, 2, 2, 3, 4, 3, 0, 1, 0, 0, 3, 4, 1, 0, 3, 2, 3, 4,
-      3, 1, 0, 4, 0, 3, 4, 3, 3, 0, 3, 1, 4, 0, 2, 1, 4, 4, 4, 3, 3, 3, 4, 3, 2, 2,
-      2, 3, 2, 2, 1, 2, 3, 3, 3, 0, 3, 2, 1, 4, 3, 4, 2, 4, 0, 1, 2, 1, 0, 0, 0, 3,
-      3, 3, 1, 4, 2, 1, 1, 1, 0, 3, 3, 4, 3, 1, 1, 1, 3, 1, 3, 2, 4, 2, 2, 0, 3, 3,
-      1, 0, 2, 0, 4, 1, 2, 0, 3, 2, 2, 3, 1, 0, 3, 3, 0, 1, 0, 1, 0, 0, 2, 2, 3, 0,
-      4, 1, 4, 1, 1, 3, 2, 2, 1, 0, 3, 2, 0, 1, 0, 2, 2, 0, 2, 1, 0, 1, 0, 0, 3, 1,
-      1, 2, 3, 0, 0, 3, 1, 2, 3, 1, 3, 3, 3, 4, 4, 2, 4, 3, 1, 2, 1, 4, 3, 4, 4, 3,
-      0, 3, 4, 2, 3, 3, 2, 4, 3, 2, 4, 1, 4, 2, 1, 3, 4, 0, 1, 3, 0, 0, 1, 2, 0, 4,
-      0, 2, 4, 3, 1, 0, 0, 1, 4, 3, 2, 4, 0, 2, 3, 1, 4, 0, 2, 2, 1, 0, 0, 2, 0, 2,
-      0, 3, 3, 3, 0, 2, 2, 4, 2, 3, 3, 1, 2, 1, 3, 1, 0, 2, 3, 0, 3, 0, 4, 4, 4, 3,
-      4, 0, 2, 3, 3, 3, 4, 4, 0, 4, 4, 1, 0, 2, 3, 4, 2, 3, 3, 3, 4, 4, 1, 1, 0, 0,
-      4, 4, 1, 3, 0, 2, 2, 1, 2, 4, 2, 0, 1, 3, 2, 0, 2, 2, 3, 3, 3, 2, 3, 0, 4, 1,
-      2, 4, 0, 1, 1, 3, 3, 3, 4, 3, 3, 2, 1, 0, 2, 2, 0, 4, 3, 0, 2, 3, 1, 4, 4, 2,
-      4, 0, 0, 2, 1, 4, 3, 4, 2, 1, 3, 4, 2, 4, 0, 4, 4, 2, 3, 0, 2, 4, 4, 1, 0, 2,
-      1, 3, 3, 4, 2, 2, 0, 1, 0, 1, 2, 4, 2, 0, 3, 1, 2, 4, 4, 2, 4, 2, 1, 0, 3, 3,
-      0, 1, 0, 1, 1, 1, 3, 3, 0, 0, 4, 4, 0, 2, 4, 2, 4, 3, 2, 2, 0, 1, 1, 3, 3, 2,
-      1, 4, 0, 0, 1, 0]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 0}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 1}
+    - {activation_epoch: 89, exit_epoch: 919, original_index: 2}
+    - {activation_epoch: 1079, exit_epoch: 1936, original_index: 3}
+    - {activation_epoch: 980, exit_epoch: 1023, original_index: 4}
+    - {activation_epoch: 711, exit_epoch: 1015, original_index: 5}
+    - {activation_epoch: 882, exit_epoch: 1034, original_index: 6}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 7}
+    - {activation_epoch: 969, exit_epoch: 18446744073709551615, original_index: 8}
+    - {activation_epoch: 1002, exit_epoch: 3766, original_index: 9}
+    - {activation_epoch: 1041, exit_epoch: 18446744073709551615, original_index: 10}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 11}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 12}
+    - {activation_epoch: 939, exit_epoch: 1017, original_index: 13}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 14}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 15}
+    - {activation_epoch: 37, exit_epoch: 980, original_index: 16}
+    - {activation_epoch: 470, exit_epoch: 1085, original_index: 17}
+    - {activation_epoch: 980, exit_epoch: 4778, original_index: 18}
+    - {activation_epoch: 66, exit_epoch: 1022, original_index: 19}
+    - {activation_epoch: 982, exit_epoch: 2464, original_index: 20}
+    - {activation_epoch: 928, exit_epoch: 18446744073709551615, original_index: 21}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 22}
+    - {activation_epoch: 560, exit_epoch: 1033, original_index: 23}
+    - {activation_epoch: 1050, exit_epoch: 18446744073709551615, original_index: 24}
+    - {activation_epoch: 1018, exit_epoch: 18446744073709551615, original_index: 25}
+    - {activation_epoch: 927, exit_epoch: 3050, original_index: 26}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 27}
+    - {activation_epoch: 717, exit_epoch: 1046, original_index: 28}
+    - {activation_epoch: 188, exit_epoch: 1044, original_index: 29}
+    - {activation_epoch: 1006, exit_epoch: 18446744073709551615, original_index: 30}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 31}
+    - {activation_epoch: 985, exit_epoch: 1590, original_index: 32}
+    - {activation_epoch: 987, exit_epoch: 1008, original_index: 33}
+    - {activation_epoch: 547, exit_epoch: 938, original_index: 34}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 35}
+    - {activation_epoch: 3, exit_epoch: 975, original_index: 36}
+    - {activation_epoch: 286, exit_epoch: 1081, original_index: 37}
+    - {activation_epoch: 965, exit_epoch: 1246, original_index: 38}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 39}
+    - {activation_epoch: 319, exit_epoch: 924, original_index: 40}
+    - {activation_epoch: 1034, exit_epoch: 1064, original_index: 41}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 42}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 43}
+    - {activation_epoch: 1043, exit_epoch: 18446744073709551615, original_index: 44}
+    - {activation_epoch: 1045, exit_epoch: 18446744073709551615, original_index: 45}
+    - {activation_epoch: 1033, exit_epoch: 2202, original_index: 46}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 47}
+    - {activation_epoch: 356, exit_epoch: 1026, original_index: 48}
+    - {activation_epoch: 981, exit_epoch: 18446744073709551615, original_index: 49}
+    - {activation_epoch: 65, exit_epoch: 1044, original_index: 50}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 51}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 52}
+    - {activation_epoch: 1036, exit_epoch: 18446744073709551615, original_index: 53}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 54}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 55}
+    - {activation_epoch: 890, exit_epoch: 1867, original_index: 56}
+    - {activation_epoch: 1065, exit_epoch: 18446744073709551615, original_index: 57}
+    - {activation_epoch: 27, exit_epoch: 923, original_index: 58}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 59}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 60}
+    - {activation_epoch: 1014, exit_epoch: 18446744073709551615, original_index: 61}
+    - {activation_epoch: 1021, exit_epoch: 3533, original_index: 62}
+    - {activation_epoch: 257, exit_epoch: 1013, original_index: 63}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 64}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 65}
+    - {activation_epoch: 1003, exit_epoch: 4066, original_index: 66}
+    - {activation_epoch: 318, exit_epoch: 940, original_index: 67}
+    - {activation_epoch: 1028, exit_epoch: 1755, original_index: 68}
+    - {activation_epoch: 986, exit_epoch: 1061, original_index: 69}
+    - {activation_epoch: 1093, exit_epoch: 3824, original_index: 70}
+    - {activation_epoch: 971, exit_epoch: 18446744073709551615, original_index: 71}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 72}
+    - {activation_epoch: 30, exit_epoch: 1068, original_index: 73}
+    - {activation_epoch: 1014, exit_epoch: 2770, original_index: 74}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 75}
+    - {activation_epoch: 221, exit_epoch: 1004, original_index: 76}
+    - {activation_epoch: 30, exit_epoch: 987, original_index: 77}
+    - {activation_epoch: 1016, exit_epoch: 3934, original_index: 78}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 79}
+    - {activation_epoch: 54, exit_epoch: 978, original_index: 80}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 1015, exit_epoch: 18446744073709551615, original_index: 82}
+    - {activation_epoch: 872, exit_epoch: 1038, original_index: 83}
+    - {activation_epoch: 399, exit_epoch: 1018, original_index: 84}
+    - {activation_epoch: 1017, exit_epoch: 18446744073709551615, original_index: 85}
+    - {activation_epoch: 46, exit_epoch: 1044, original_index: 86}
+    - {activation_epoch: 65, exit_epoch: 971, original_index: 87}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 88}
+    - {activation_epoch: 963, exit_epoch: 18446744073709551615, original_index: 89}
+    - {activation_epoch: 464, exit_epoch: 968, original_index: 90}
+    - {activation_epoch: 417, exit_epoch: 1053, original_index: 91}
+    - {activation_epoch: 1035, exit_epoch: 4308, original_index: 92}
+    - {activation_epoch: 929, exit_epoch: 3096, original_index: 93}
+    - {activation_epoch: 556, exit_epoch: 967, original_index: 94}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 95}
+    - {activation_epoch: 1031, exit_epoch: 4274, original_index: 96}
+    - {activation_epoch: 330, exit_epoch: 973, original_index: 97}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 98}
+    - {activation_epoch: 581, exit_epoch: 1041, original_index: 99}
+    - {activation_epoch: 997, exit_epoch: 2628, original_index: 100}
+    - {activation_epoch: 988, exit_epoch: 2879, original_index: 101}
+    - {activation_epoch: 985, exit_epoch: 18446744073709551615, original_index: 102}
+    - {activation_epoch: 849, exit_epoch: 976, original_index: 103}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 104}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 105}
+    - {activation_epoch: 477, exit_epoch: 987, original_index: 106}
+    - {activation_epoch: 985, exit_epoch: 18446744073709551615, original_index: 107}
+    - {activation_epoch: 1063, exit_epoch: 4727, original_index: 108}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 109}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 110}
+    - {activation_epoch: 1027, exit_epoch: 1052, original_index: 111}
+    - {activation_epoch: 985, exit_epoch: 1011, original_index: 112}
+    - {activation_epoch: 124, exit_epoch: 1023, original_index: 113}
+    - {activation_epoch: 286, exit_epoch: 994, original_index: 114}
+    - {activation_epoch: 1045, exit_epoch: 18446744073709551615, original_index: 115}
+    - {activation_epoch: 991, exit_epoch: 1791, original_index: 116}
+    - {activation_epoch: 911, exit_epoch: 1050, original_index: 117}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 118}
+    - {activation_epoch: 1000, exit_epoch: 1012, original_index: 119}
+    - {activation_epoch: 483, exit_epoch: 928, original_index: 120}
+    - {activation_epoch: 1021, exit_epoch: 1048, original_index: 121}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 122}
+    - {activation_epoch: 797, exit_epoch: 960, original_index: 123}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 124}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 125}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 126}
+    - {activation_epoch: 940, exit_epoch: 977, original_index: 127}
+    - {activation_epoch: 823, exit_epoch: 934, original_index: 128}
+    - {activation_epoch: 979, exit_epoch: 2868, original_index: 129}
+    - {activation_epoch: 1031, exit_epoch: 18446744073709551615, original_index: 130}
+    - {activation_epoch: 631, exit_epoch: 986, original_index: 131}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 132}
+    - {activation_epoch: 536, exit_epoch: 978, original_index: 133}
+    - {activation_epoch: 971, exit_epoch: 2842, original_index: 134}
+    - {activation_epoch: 723, exit_epoch: 1042, original_index: 135}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 136}
+    - {activation_epoch: 310, exit_epoch: 1004, original_index: 137}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 138}
+    - {activation_epoch: 1000, exit_epoch: 1035, original_index: 139}
+    - {activation_epoch: 668, exit_epoch: 984, original_index: 140}
+    - {activation_epoch: 1057, exit_epoch: 18446744073709551615, original_index: 141}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 142}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 143}
+    - {activation_epoch: 394, exit_epoch: 1004, original_index: 144}
+    - {activation_epoch: 709, exit_epoch: 940, original_index: 145}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 146}
+    - {activation_epoch: 1057, exit_epoch: 3291, original_index: 147}
+    - {activation_epoch: 991, exit_epoch: 3690, original_index: 148}
+    - {activation_epoch: 949, exit_epoch: 1059, original_index: 149}
+    - {activation_epoch: 999, exit_epoch: 1289, original_index: 150}
+    - {activation_epoch: 996, exit_epoch: 18446744073709551615, original_index: 151}
+    - {activation_epoch: 744, exit_epoch: 995, original_index: 152}
+    - {activation_epoch: 944, exit_epoch: 18446744073709551615, original_index: 153}
+    - {activation_epoch: 770, exit_epoch: 1021, original_index: 154}
+    - {activation_epoch: 758, exit_epoch: 1051, original_index: 155}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 156}
+    - {activation_epoch: 771, exit_epoch: 951, original_index: 157}
+    - {activation_epoch: 431, exit_epoch: 989, original_index: 158}
+    - {activation_epoch: 468, exit_epoch: 1008, original_index: 159}
+    - {activation_epoch: 549, exit_epoch: 1015, original_index: 160}
+    - {activation_epoch: 1034, exit_epoch: 18446744073709551615, original_index: 161}
+    - {activation_epoch: 1009, exit_epoch: 3648, original_index: 162}
+    - {activation_epoch: 380, exit_epoch: 1015, original_index: 163}
+    - {activation_epoch: 362, exit_epoch: 987, original_index: 164}
+    - {activation_epoch: 463, exit_epoch: 1077, original_index: 165}
+    - {activation_epoch: 409, exit_epoch: 964, original_index: 166}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 167}
+    - {activation_epoch: 991, exit_epoch: 18446744073709551615, original_index: 168}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 169}
+    - {activation_epoch: 728, exit_epoch: 936, original_index: 170}
+    - {activation_epoch: 1032, exit_epoch: 3300, original_index: 171}
+    - {activation_epoch: 1057, exit_epoch: 1356, original_index: 172}
+    - {activation_epoch: 552, exit_epoch: 1068, original_index: 173}
+    - {activation_epoch: 1003, exit_epoch: 2783, original_index: 174}
+    - {activation_epoch: 151, exit_epoch: 1010, original_index: 175}
+    - {activation_epoch: 947, exit_epoch: 2505, original_index: 176}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 177}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 178}
+    - {activation_epoch: 948, exit_epoch: 974, original_index: 179}
+    - {activation_epoch: 174, exit_epoch: 1026, original_index: 180}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 181}
+    - {activation_epoch: 938, exit_epoch: 18446744073709551615, original_index: 182}
+    - {activation_epoch: 625, exit_epoch: 1059, original_index: 183}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 184}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 185}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 186}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 187}
+    - {activation_epoch: 1016, exit_epoch: 1024, original_index: 188}
+    - {activation_epoch: 386, exit_epoch: 1044, original_index: 189}
+    - {activation_epoch: 1065, exit_epoch: 4189, original_index: 190}
+    - {activation_epoch: 918, exit_epoch: 994, original_index: 191}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 192}
+    - {activation_epoch: 52, exit_epoch: 981, original_index: 193}
+    - {activation_epoch: 1009, exit_epoch: 3590, original_index: 194}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 195}
+    - {activation_epoch: 447, exit_epoch: 1004, original_index: 196}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 197}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 198}
+    - {activation_epoch: 524, exit_epoch: 984, original_index: 199}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 200}
+    - {activation_epoch: 1000, exit_epoch: 18446744073709551615, original_index: 201}
+    - {activation_epoch: 1038, exit_epoch: 4403, original_index: 202}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 203}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 204}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 205}
+    - {activation_epoch: 1030, exit_epoch: 1896, original_index: 206}
+    - {activation_epoch: 776, exit_epoch: 1024, original_index: 207}
+    - {activation_epoch: 34, exit_epoch: 1005, original_index: 208}
+    - {activation_epoch: 1025, exit_epoch: 18446744073709551615, original_index: 209}
+    - {activation_epoch: 971, exit_epoch: 1008, original_index: 210}
+    - {activation_epoch: 395, exit_epoch: 1040, original_index: 211}
+    - {activation_epoch: 1010, exit_epoch: 2278, original_index: 212}
+    - {activation_epoch: 787, exit_epoch: 1020, original_index: 213}
+    - {activation_epoch: 309, exit_epoch: 1010, original_index: 214}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 215}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 216}
+    - {activation_epoch: 123, exit_epoch: 1023, original_index: 217}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 218}
+    - {activation_epoch: 40, exit_epoch: 944, original_index: 219}
+    - {activation_epoch: 837, exit_epoch: 1040, original_index: 220}
+    - {activation_epoch: 244, exit_epoch: 1022, original_index: 221}
+    - {activation_epoch: 834, exit_epoch: 946, original_index: 222}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 223}
+    - {activation_epoch: 550, exit_epoch: 933, original_index: 224}
+    - {activation_epoch: 961, exit_epoch: 1029, original_index: 225}
+    - {activation_epoch: 1044, exit_epoch: 18446744073709551615, original_index: 226}
+    - {activation_epoch: 402, exit_epoch: 971, original_index: 227}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 228}
+    - {activation_epoch: 970, exit_epoch: 18446744073709551615, original_index: 229}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 230}
+    - {activation_epoch: 372, exit_epoch: 1005, original_index: 231}
+    - {activation_epoch: 981, exit_epoch: 1009, original_index: 232}
+    - {activation_epoch: 518, exit_epoch: 995, original_index: 233}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 234}
+    - {activation_epoch: 362, exit_epoch: 1025, original_index: 235}
+    - {activation_epoch: 967, exit_epoch: 1732, original_index: 236}
+    - {activation_epoch: 975, exit_epoch: 3201, original_index: 237}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 238}
+    - {activation_epoch: 432, exit_epoch: 985, original_index: 239}
+    - {activation_epoch: 258, exit_epoch: 986, original_index: 240}
+    - {activation_epoch: 1043, exit_epoch: 18446744073709551615, original_index: 241}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 242}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 243}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 244}
+    - {activation_epoch: 1055, exit_epoch: 18446744073709551615, original_index: 245}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 246}
+    - {activation_epoch: 588, exit_epoch: 1037, original_index: 247}
+    - {activation_epoch: 1002, exit_epoch: 2755, original_index: 248}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 249}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 250}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 251}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 252}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 253}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 254}
+    - {activation_epoch: 960, exit_epoch: 1425, original_index: 255}
+    - {activation_epoch: 1028, exit_epoch: 3425, original_index: 256}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 257}
+    - {activation_epoch: 542, exit_epoch: 963, original_index: 258}
+    - {activation_epoch: 1042, exit_epoch: 2165, original_index: 259}
+    - {activation_epoch: 371, exit_epoch: 994, original_index: 260}
+    - {activation_epoch: 954, exit_epoch: 18446744073709551615, original_index: 261}
+    - {activation_epoch: 633, exit_epoch: 1029, original_index: 262}
+    - {activation_epoch: 905, exit_epoch: 969, original_index: 263}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 264}
+    - {activation_epoch: 479, exit_epoch: 1021, original_index: 265}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 266}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 267}
+    - {activation_epoch: 749, exit_epoch: 975, original_index: 268}
+    - {activation_epoch: 540, exit_epoch: 1025, original_index: 269}
+    - {activation_epoch: 1057, exit_epoch: 18446744073709551615, original_index: 270}
+    - {activation_epoch: 792, exit_epoch: 935, original_index: 271}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 272}
+    - {activation_epoch: 541, exit_epoch: 1009, original_index: 273}
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 274}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 275}
+    - {activation_epoch: 222, exit_epoch: 972, original_index: 276}
+    - {activation_epoch: 1001, exit_epoch: 3235, original_index: 277}
+    - {activation_epoch: 791, exit_epoch: 987, original_index: 278}
+    - {activation_epoch: 248, exit_epoch: 1032, original_index: 279}
+    - {activation_epoch: 976, exit_epoch: 3538, original_index: 280}
+    - {activation_epoch: 621, exit_epoch: 1001, original_index: 281}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 282}
+    - {activation_epoch: 499, exit_epoch: 985, original_index: 283}
+    - {activation_epoch: 191, exit_epoch: 935, original_index: 284}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 285}
+    - {activation_epoch: 384, exit_epoch: 964, original_index: 286}
+    - {activation_epoch: 179, exit_epoch: 1010, original_index: 287}
+    - {activation_epoch: 1056, exit_epoch: 18446744073709551615, original_index: 288}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 289}
+    - {activation_epoch: 154, exit_epoch: 980, original_index: 290}
+    - {activation_epoch: 500, exit_epoch: 1011, original_index: 291}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 292}
+    - {activation_epoch: 651, exit_epoch: 963, original_index: 293}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 294}
+    - {activation_epoch: 530, exit_epoch: 980, original_index: 295}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 296}
+    - {activation_epoch: 953, exit_epoch: 4073, original_index: 297}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 298}
+    - {activation_epoch: 768, exit_epoch: 992, original_index: 299}
+    - {activation_epoch: 918, exit_epoch: 1017, original_index: 300}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 301}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 302}
+    - {activation_epoch: 338, exit_epoch: 959, original_index: 303}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 304}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 305}
+    - {activation_epoch: 874, exit_epoch: 970, original_index: 306}
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 307}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 308}
+    - {activation_epoch: 917, exit_epoch: 1012, original_index: 309}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 310}
+    - {activation_epoch: 892, exit_epoch: 1005, original_index: 311}
+    - {activation_epoch: 1075, exit_epoch: 3974, original_index: 312}
+    - {activation_epoch: 956, exit_epoch: 1392, original_index: 313}
+    - {activation_epoch: 977, exit_epoch: 4647, original_index: 314}
+    - {activation_epoch: 1037, exit_epoch: 1074, original_index: 315}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 316}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 317}
+    - {activation_epoch: 53, exit_epoch: 976, original_index: 318}
+    - {activation_epoch: 1027, exit_epoch: 18446744073709551615, original_index: 319}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 320}
+    - {activation_epoch: 1027, exit_epoch: 18446744073709551615, original_index: 321}
+    - {activation_epoch: 985, exit_epoch: 18446744073709551615, original_index: 322}
+    - {activation_epoch: 1006, exit_epoch: 1018, original_index: 323}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 324}
+    - {activation_epoch: 967, exit_epoch: 3116, original_index: 325}
+    - {activation_epoch: 540, exit_epoch: 1028, original_index: 326}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 327}
+    - {activation_epoch: 1027, exit_epoch: 18446744073709551615, original_index: 328}
+    - {activation_epoch: 181, exit_epoch: 1014, original_index: 329}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 330}
+    - {activation_epoch: 358, exit_epoch: 1016, original_index: 331}
+    - {activation_epoch: 991, exit_epoch: 18446744073709551615, original_index: 332}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 333}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 334}
+    - {activation_epoch: 589, exit_epoch: 1072, original_index: 335}
+    - {activation_epoch: 1020, exit_epoch: 18446744073709551615, original_index: 336}
+    - {activation_epoch: 948, exit_epoch: 3186, original_index: 337}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 338}
+    - {activation_epoch: 979, exit_epoch: 1514, original_index: 339}
+    - {activation_epoch: 595, exit_epoch: 1051, original_index: 340}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 341}
+    - {activation_epoch: 173, exit_epoch: 965, original_index: 342}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 343}
+    - {activation_epoch: 1061, exit_epoch: 18446744073709551615, original_index: 344}
+    - {activation_epoch: 1036, exit_epoch: 18446744073709551615, original_index: 345}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 346}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 347}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 348}
+    - {activation_epoch: 979, exit_epoch: 18446744073709551615, original_index: 349}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 350}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 351}
+    - {activation_epoch: 547, exit_epoch: 994, original_index: 352}
+    - {activation_epoch: 1063, exit_epoch: 3939, original_index: 353}
+    - {activation_epoch: 289, exit_epoch: 1004, original_index: 354}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 355}
+    - {activation_epoch: 420, exit_epoch: 1039, original_index: 356}
+    - {activation_epoch: 694, exit_epoch: 1016, original_index: 357}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 358}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 359}
+    - {activation_epoch: 1013, exit_epoch: 3439, original_index: 360}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 361}
+    - {activation_epoch: 22, exit_epoch: 972, original_index: 362}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 363}
+    - {activation_epoch: 1051, exit_epoch: 3500, original_index: 364}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 365}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 366}
+    - {activation_epoch: 83, exit_epoch: 1019, original_index: 367}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 368}
+    - {activation_epoch: 680, exit_epoch: 955, original_index: 369}
+    - {activation_epoch: 644, exit_epoch: 1016, original_index: 370}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 371}
+    - {activation_epoch: 443, exit_epoch: 1000, original_index: 372}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 373}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 374}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 375}
+    - {activation_epoch: 719, exit_epoch: 1011, original_index: 376}
+    - {activation_epoch: 283, exit_epoch: 1004, original_index: 377}
+    - {activation_epoch: 541, exit_epoch: 1009, original_index: 378}
+    - {activation_epoch: 1044, exit_epoch: 3042, original_index: 379}
+    - {activation_epoch: 568, exit_epoch: 1008, original_index: 380}
+    - {activation_epoch: 756, exit_epoch: 1030, original_index: 381}
+    - {activation_epoch: 448, exit_epoch: 1046, original_index: 382}
+    - {activation_epoch: 1009, exit_epoch: 3704, original_index: 383}
+    - {activation_epoch: 935, exit_epoch: 2622, original_index: 384}
+    - {activation_epoch: 422, exit_epoch: 1024, original_index: 385}
+    - {activation_epoch: 367, exit_epoch: 985, original_index: 386}
+    - {activation_epoch: 979, exit_epoch: 1028, original_index: 387}
+    - {activation_epoch: 1019, exit_epoch: 18446744073709551615, original_index: 388}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 389}
+    - {activation_epoch: 390, exit_epoch: 1027, original_index: 390}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 391}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 392}
+    - {activation_epoch: 999, exit_epoch: 18446744073709551615, original_index: 393}
+    - {activation_epoch: 37, exit_epoch: 1060, original_index: 394}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 395}
+    - {activation_epoch: 1035, exit_epoch: 18446744073709551615, original_index: 396}
+    - {activation_epoch: 943, exit_epoch: 2067, original_index: 397}
+    - {activation_epoch: 338, exit_epoch: 990, original_index: 398}
+    - {activation_epoch: 999, exit_epoch: 18446744073709551615, original_index: 399}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 400}
+    - {activation_epoch: 1044, exit_epoch: 18446744073709551615, original_index: 401}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 402}
+    - {activation_epoch: 993, exit_epoch: 1292, original_index: 403}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 404}
+    - {activation_epoch: 371, exit_epoch: 1015, original_index: 405}
+    - {activation_epoch: 882, exit_epoch: 1024, original_index: 406}
+    - {activation_epoch: 455, exit_epoch: 970, original_index: 407}
+    - {activation_epoch: 298, exit_epoch: 988, original_index: 408}
+    - {activation_epoch: 993, exit_epoch: 4611, original_index: 409}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 410}
+    - {activation_epoch: 1042, exit_epoch: 2334, original_index: 411}
+    - {activation_epoch: 1019, exit_epoch: 18446744073709551615, original_index: 412}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 413}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 414}
+    - {activation_epoch: 423, exit_epoch: 992, original_index: 415}
+    - {activation_epoch: 986, exit_epoch: 1700, original_index: 416}
   output:
-  - - committee: [429, 203]
-      shard: 102
-      total_validator_count: 177
-  - - committee: [404, 383, 197]
-      shard: 103
-      total_validator_count: 177
-  - - committee: [194, 30, 342]
-      shard: 104
-      total_validator_count: 177
-  - - committee: [440, 317, 109]
-      shard: 105
-      total_validator_count: 177
-  - - committee: [237, 145]
-      shard: 106
-      total_validator_count: 177
-  - - committee: [410, 128, 13]
-      shard: 107
-      total_validator_count: 177
-  - - committee: [308, 277, 177]
-      shard: 108
-      total_validator_count: 177
-  - - committee: [187, 291, 100]
-      shard: 109
-      total_validator_count: 177
-  - - committee: [192, 126]
-      shard: 110
-      total_validator_count: 177
-  - - committee: [293, 437, 370]
-      shard: 111
-      total_validator_count: 177
-  - - committee: [14, 101, 56]
-      shard: 112
-      total_validator_count: 177
-  - - committee: [156, 182, 138]
-      shard: 113
-      total_validator_count: 177
-  - - committee: [461, 286]
-      shard: 114
-      total_validator_count: 177
-  - - committee: [319, 393, 388]
-      shard: 115
-      total_validator_count: 177
-  - - committee: [19, 152, 466]
-      shard: 116
-      total_validator_count: 177
-  - - committee: [155, 231, 392]
-      shard: 117
-      total_validator_count: 177
-  - - committee: [264, 35, 414]
-      shard: 118
-      total_validator_count: 177
-  - - committee: [221, 401]
-      shard: 119
-      total_validator_count: 177
-  - - committee: [339, 159, 297]
-      shard: 120
-      total_validator_count: 177
-  - - committee: [380, 102, 222]
-      shard: 121
-      total_validator_count: 177
-  - - committee: [420, 353, 328]
-      shard: 122
-      total_validator_count: 177
-  - - committee: [274, 439]
-      shard: 123
-      total_validator_count: 177
-  - - committee: [234, 432, 173]
-      shard: 124
-      total_validator_count: 177
-  - - committee: [32, 41, 131]
-      shard: 125
-      total_validator_count: 177
-  - - committee: [114, 202, 86]
-      shard: 126
-      total_validator_count: 177
-  - - committee: [118, 141]
-      shard: 127
-      total_validator_count: 177
-  - - committee: [454, 96, 146]
-      shard: 128
-      total_validator_count: 177
-  - - committee: [129, 419, 179]
-      shard: 129
-      total_validator_count: 177
-  - - committee: [361, 455, 242]
-      shard: 130
-      total_validator_count: 177
-  - - committee: [162, 373]
-      shard: 131
-      total_validator_count: 177
-  - - committee: [119, 272, 117]
-      shard: 132
-      total_validator_count: 177
-  - - committee: [172, 169, 357]
-      shard: 133
-      total_validator_count: 177
-  - - committee: [349, 426, 36]
-      shard: 134
-      total_validator_count: 177
-  - - committee: [55, 61, 415]
-      shard: 135
-      total_validator_count: 177
-  - - committee: [457, 150]
-      shard: 136
-      total_validator_count: 177
-  - - committee: [267, 38, 209]
-      shard: 137
-      total_validator_count: 177
-  - - committee: [431, 191, 407]
-      shard: 138
-      total_validator_count: 177
-  - - committee: [425, 261, 239]
-      shard: 139
-      total_validator_count: 177
-  - - committee: [387, 26]
-      shard: 140
-      total_validator_count: 177
-  - - committee: [189, 143, 285]
-      shard: 141
-      total_validator_count: 177
-  - - committee: [338, 137, 348]
-      shard: 142
-      total_validator_count: 177
-  - - committee: [110, 43, 269]
-      shard: 143
-      total_validator_count: 177
-  - - committee: [18, 451]
-      shard: 144
-      total_validator_count: 177
-  - - committee: [130, 184, 15]
-      shard: 145
-      total_validator_count: 177
-  - - committee: [462, 417, 458]
-      shard: 146
-      total_validator_count: 177
-  - - committee: [337, 217, 83]
-      shard: 147
-      total_validator_count: 177
-  - - committee: [139, 195]
-      shard: 148
-      total_validator_count: 177
-  - - committee: [103, 1, 358]
-      shard: 149
-      total_validator_count: 177
-  - - committee: [201, 73, 340]
-      shard: 150
-      total_validator_count: 177
-  - - committee: [98, 396, 449]
-      shard: 151
-      total_validator_count: 177
-  - - committee: [344, 409, 180]
-      shard: 152
-      total_validator_count: 177
-  - - committee: [66, 5]
-      shard: 153
-      total_validator_count: 177
-  - - committee: [46, 69, 220]
-      shard: 154
-      total_validator_count: 177
-  - - committee: [258, 167, 97]
-      shard: 155
-      total_validator_count: 177
-  - - committee: [208, 422, 372]
-      shard: 156
-      total_validator_count: 177
-  - - committee: [441, 246]
-      shard: 157
-      total_validator_count: 177
-  - - committee: [87, 346, 322]
-      shard: 158
-      total_validator_count: 177
-  - - committee: [329, 279, 255]
-      shard: 159
-      total_validator_count: 177
-  - - committee: [160, 288, 295]
-      shard: 160
-      total_validator_count: 177
-  - - committee: [250, 211]
-      shard: 161
-      total_validator_count: 177
-  - - committee: [292, 183, 24]
-      shard: 162
-      total_validator_count: 177
-  - - committee: [27, 334, 378]
-      shard: 163
-      total_validator_count: 177
-  - - committee: [273, 50, 369]
-      shard: 164
-      total_validator_count: 177
-  - - committee: [251, 241, 362]
-      shard: 165
-      total_validator_count: 177
-  seed: '0xadb35f3fc2880d220e520120a032bbaa0f4bd7a5fcf1c2269de21075e7a46471'
+  - [385, 32]
+  - [83, 220, 99]
+  - [4, 117]
+  - [382, 261, 339]
+  - [126, 384]
+  - [255, 51, 376]
+  - [232, 138]
+  - [23, 340, 399]
+  - [11, 381]
+  - [329, 176, 50]
+  - [208, 33, 349]
+  - [5, 29]
+  - [60, 325, 238]
+  - [354, 160]
+  - [56, 189, 182]
+  - [73, 159]
+  - [69, 144, 229]
+  - [242, 107]
+  - [211, 311, 409]
+  - [236, 357]
+  - [119, 35, 391]
+  - [37, 416, 380]
+  - [154, 89]
+  - [347, 7, 221]
+  - [254, 168]
+  - [247, 301, 112]
+  - [100, 335]
+  - [387, 326, 63]
+  - [210, 13]
+  - [287, 314, 139]
+  - [403, 300]
+  - [373, 91, 370]
+  - [81, 149, 291]
+  - [217, 52]
+  - [38, 367, 165]
+  - [368, 279]
+  - [265, 322, 361]
+  - [26, 88]
+  - [214, 213, 390]
+  - [155, 148]
+  - [406, 93, 356]
+  - [19, 18]
+  - [173, 333, 337]
+  - [297, 269, 175]
+  - [49, 71]
+  - [183, 124, 237]
+  - [378, 225]
+  - [76, 163, 151]
+  - [207, 135]
+  - [332, 134, 48]
+  - [180, 350]
+  - [113, 331, 101]
+  - [137, 201]
+  - [86, 196, 273]
+  - [153, 102, 235]
+  - [21, 280]
+  - [397, 377, 84]
+  - [313, 8]
+  - [309, 393, 17]
+  - [394, 20]
+  - [6, 116, 129]
+  - [281, 355]
+  - [231, 150, 59]
+  - [262, 28, 405]
+  seed: '0x54862abc8bc52ee4d0bffe8b7bc2d61f22d7d31f41d4e7bab6adb77663a1ac43'
 - input:
-    crosslinking_start_shard: 133
-    validators_status: [2, 0, 4, 2, 4, 2, 0, 3, 1, 0, 2, 1, 0, 3, 2, 2, 0, 0, 3, 4,
-      1, 2, 4, 0, 0, 0, 2, 3, 0, 3, 4, 1, 0, 1, 4, 0, 3, 0, 4, 1, 0, 3, 2, 3, 4, 0,
-      3, 3, 4, 3, 3, 4, 1, 3, 3, 1, 0, 0, 0, 0, 2, 2, 1, 3, 4, 4, 4, 3, 3, 3, 4, 3,
-      3, 1, 2, 3, 2, 3, 3, 3, 2, 2, 2, 4, 0, 0, 1, 2, 2, 4, 4, 4, 2, 0, 4, 0, 1, 1,
-      4, 3, 4, 4, 3, 4, 0, 1, 0, 1, 1, 3, 3, 0, 0, 0, 1, 3, 2, 0, 0, 4, 2, 1, 0, 4,
-      3, 0, 4, 0, 0, 0, 3, 0, 4, 1, 1, 1, 4, 1, 0, 3, 2, 4, 2, 0, 4, 2, 3, 4, 1, 1,
-      0, 1, 3, 2, 2, 2, 3, 0, 3, 0, 1, 0, 2, 0, 2, 1, 1, 4, 1, 2, 4, 1, 1, 4, 0, 3,
-      2, 3, 0, 4, 1, 0, 0, 0, 4, 1, 3, 0, 3, 1, 4, 3, 2, 0, 2, 4, 1, 3, 1, 4, 1, 3,
-      2, 1, 2, 4, 0, 3, 1, 1, 0, 3, 1, 1, 2, 1, 4, 2, 1, 4, 0, 3, 2, 0, 0, 4, 3, 2,
-      1, 2, 3, 1, 1, 1, 4, 2, 2, 0, 1, 1, 0, 4, 4, 2, 0, 4, 1, 3, 0, 0, 0, 1, 3, 1,
-      4, 3, 0, 1, 0, 2, 4, 1, 0, 1, 1, 0, 4, 3, 1, 1, 1, 2, 0, 0, 0, 4, 0, 2, 2, 0,
-      4, 2, 3, 2, 4, 4, 3, 4, 3, 3, 0, 3, 0, 2, 2, 4, 1, 4, 4, 4, 3, 2, 3, 2, 0, 2,
-      2, 2, 4, 2, 4, 1, 0, 1, 0, 4, 0, 4, 1, 1, 2, 2, 4, 3, 4, 4, 3, 3, 4, 2, 3, 0,
-      2, 1, 4, 0, 0, 4, 1, 2, 1, 4, 1, 2, 0, 4, 4, 1, 4, 1, 1, 4]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 955, exit_epoch: 18446744073709551615, original_index: 0}
+    - {activation_epoch: 514, exit_epoch: 1049, original_index: 1}
+    - {activation_epoch: 688, exit_epoch: 987, original_index: 2}
+    - {activation_epoch: 995, exit_epoch: 4569, original_index: 3}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 4}
+    - {activation_epoch: 359, exit_epoch: 1022, original_index: 5}
+    - {activation_epoch: 22, exit_epoch: 991, original_index: 6}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 7}
+    - {activation_epoch: 1059, exit_epoch: 2216, original_index: 8}
+    - {activation_epoch: 803, exit_epoch: 1002, original_index: 9}
+    - {activation_epoch: 766, exit_epoch: 988, original_index: 10}
+    - {activation_epoch: 1000, exit_epoch: 4114, original_index: 11}
+    - {activation_epoch: 401, exit_epoch: 932, original_index: 12}
+    - {activation_epoch: 666, exit_epoch: 1019, original_index: 13}
+    - {activation_epoch: 930, exit_epoch: 999, original_index: 14}
+    - {activation_epoch: 773, exit_epoch: 1001, original_index: 15}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 16}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 17}
+    - {activation_epoch: 961, exit_epoch: 4231, original_index: 18}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 19}
+    - {activation_epoch: 1027, exit_epoch: 4147, original_index: 20}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 21}
+    - {activation_epoch: 975, exit_epoch: 3307, original_index: 22}
+    - {activation_epoch: 992, exit_epoch: 2607, original_index: 23}
+    - {activation_epoch: 14, exit_epoch: 1017, original_index: 24}
+    - {activation_epoch: 712, exit_epoch: 1007, original_index: 25}
+    - {activation_epoch: 15, exit_epoch: 1024, original_index: 26}
+    - {activation_epoch: 885, exit_epoch: 1031, original_index: 27}
+    - {activation_epoch: 955, exit_epoch: 18446744073709551615, original_index: 28}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 29}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 30}
+    - {activation_epoch: 988, exit_epoch: 2500, original_index: 31}
+    - {activation_epoch: 988, exit_epoch: 18446744073709551615, original_index: 32}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 33}
+    - {activation_epoch: 769, exit_epoch: 998, original_index: 34}
+    - {activation_epoch: 301, exit_epoch: 979, original_index: 35}
+    - {activation_epoch: 988, exit_epoch: 18446744073709551615, original_index: 36}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 37}
+    - {activation_epoch: 960, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 574, exit_epoch: 1002, original_index: 39}
+    - {activation_epoch: 185, exit_epoch: 970, original_index: 40}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 41}
+    - {activation_epoch: 1031, exit_epoch: 1424, original_index: 42}
+    - {activation_epoch: 705, exit_epoch: 1019, original_index: 43}
+    - {activation_epoch: 1, exit_epoch: 1037, original_index: 44}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 45}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 46}
+    - {activation_epoch: 975, exit_epoch: 18446744073709551615, original_index: 47}
+    - {activation_epoch: 132, exit_epoch: 1014, original_index: 48}
+    - {activation_epoch: 223, exit_epoch: 987, original_index: 49}
+    - {activation_epoch: 700, exit_epoch: 1015, original_index: 50}
+    - {activation_epoch: 820, exit_epoch: 980, original_index: 51}
+    - {activation_epoch: 759, exit_epoch: 948, original_index: 52}
+    - {activation_epoch: 825, exit_epoch: 959, original_index: 53}
+    - {activation_epoch: 986, exit_epoch: 2946, original_index: 54}
+    - {activation_epoch: 985, exit_epoch: 1089, original_index: 55}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 56}
+    - {activation_epoch: 993, exit_epoch: 2164, original_index: 57}
+    - {activation_epoch: 309, exit_epoch: 1041, original_index: 58}
+    - {activation_epoch: 449, exit_epoch: 1011, original_index: 59}
+    - {activation_epoch: 201, exit_epoch: 962, original_index: 60}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 61}
+    - {activation_epoch: 226, exit_epoch: 972, original_index: 62}
+    - {activation_epoch: 602, exit_epoch: 971, original_index: 63}
+    - {activation_epoch: 996, exit_epoch: 3318, original_index: 64}
+    - {activation_epoch: 1036, exit_epoch: 2110, original_index: 65}
+    - {activation_epoch: 1018, exit_epoch: 1637, original_index: 66}
+    - {activation_epoch: 202, exit_epoch: 969, original_index: 67}
+    - {activation_epoch: 1005, exit_epoch: 2796, original_index: 68}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 69}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 70}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 71}
+    - {activation_epoch: 189, exit_epoch: 1000, original_index: 72}
+    - {activation_epoch: 397, exit_epoch: 976, original_index: 73}
+    - {activation_epoch: 986, exit_epoch: 4481, original_index: 74}
+    - {activation_epoch: 850, exit_epoch: 967, original_index: 75}
+    - {activation_epoch: 577, exit_epoch: 926, original_index: 76}
+    - {activation_epoch: 324, exit_epoch: 1018, original_index: 77}
+    - {activation_epoch: 641, exit_epoch: 940, original_index: 78}
+    - {activation_epoch: 9, exit_epoch: 1044, original_index: 79}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 80}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 784, exit_epoch: 1001, original_index: 82}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 83}
+    - {activation_epoch: 985, exit_epoch: 2287, original_index: 84}
+    - {activation_epoch: 543, exit_epoch: 972, original_index: 85}
+    - {activation_epoch: 1014, exit_epoch: 4712, original_index: 86}
+    - {activation_epoch: 972, exit_epoch: 3679, original_index: 87}
+    - {activation_epoch: 983, exit_epoch: 2961, original_index: 88}
+    - {activation_epoch: 1041, exit_epoch: 18446744073709551615, original_index: 89}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 90}
+    - {activation_epoch: 121, exit_epoch: 951, original_index: 91}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 92}
+    - {activation_epoch: 447, exit_epoch: 1005, original_index: 93}
+    - {activation_epoch: 410, exit_epoch: 951, original_index: 94}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 95}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 96}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 97}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 98}
+    - {activation_epoch: 923, exit_epoch: 18446744073709551615, original_index: 99}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 100}
+    - {activation_epoch: 949, exit_epoch: 1327, original_index: 101}
+    - {activation_epoch: 961, exit_epoch: 18446744073709551615, original_index: 102}
+    - {activation_epoch: 1042, exit_epoch: 2986, original_index: 103}
+    - {activation_epoch: 910, exit_epoch: 18446744073709551615, original_index: 104}
+    - {activation_epoch: 999, exit_epoch: 18446744073709551615, original_index: 105}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 106}
+    - {activation_epoch: 778, exit_epoch: 958, original_index: 107}
+    - {activation_epoch: 618, exit_epoch: 955, original_index: 108}
+    - {activation_epoch: 144, exit_epoch: 924, original_index: 109}
+    - {activation_epoch: 1007, exit_epoch: 1189, original_index: 110}
+    - {activation_epoch: 1000, exit_epoch: 18446744073709551615, original_index: 111}
+    - {activation_epoch: 1029, exit_epoch: 18446744073709551615, original_index: 112}
+    - {activation_epoch: 908, exit_epoch: 963, original_index: 113}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 114}
+    - {activation_epoch: 685, exit_epoch: 952, original_index: 115}
+    - {activation_epoch: 602, exit_epoch: 977, original_index: 116}
+    - {activation_epoch: 855, exit_epoch: 1018, original_index: 117}
+    - {activation_epoch: 1006, exit_epoch: 18446744073709551615, original_index: 118}
+    - {activation_epoch: 962, exit_epoch: 3871, original_index: 119}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 120}
+    - {activation_epoch: 966, exit_epoch: 18446744073709551615, original_index: 121}
+    - {activation_epoch: 803, exit_epoch: 961, original_index: 122}
+    - {activation_epoch: 237, exit_epoch: 962, original_index: 123}
+    - {activation_epoch: 842, exit_epoch: 1038, original_index: 124}
+    - {activation_epoch: 963, exit_epoch: 2179, original_index: 125}
+    - {activation_epoch: 997, exit_epoch: 18446744073709551615, original_index: 126}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 127}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 128}
+    - {activation_epoch: 957, exit_epoch: 1251, original_index: 129}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 130}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 131}
+    - {activation_epoch: 912, exit_epoch: 955, original_index: 132}
+    - {activation_epoch: 333, exit_epoch: 1028, original_index: 133}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 134}
+    - {activation_epoch: 80, exit_epoch: 1040, original_index: 135}
+    - {activation_epoch: 244, exit_epoch: 984, original_index: 136}
+    - {activation_epoch: 869, exit_epoch: 1077, original_index: 137}
+    - {activation_epoch: 125, exit_epoch: 992, original_index: 138}
+    - {activation_epoch: 393, exit_epoch: 1005, original_index: 139}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 140}
+    - {activation_epoch: 746, exit_epoch: 1025, original_index: 141}
+    - {activation_epoch: 954, exit_epoch: 18446744073709551615, original_index: 142}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 143}
+    - {activation_epoch: 1046, exit_epoch: 3248, original_index: 144}
+    - {activation_epoch: 721, exit_epoch: 998, original_index: 145}
+    - {activation_epoch: 126, exit_epoch: 1014, original_index: 146}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 147}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 148}
+    - {activation_epoch: 74, exit_epoch: 958, original_index: 149}
+    - {activation_epoch: 964, exit_epoch: 2235, original_index: 150}
+    - {activation_epoch: 572, exit_epoch: 1057, original_index: 151}
+    - {activation_epoch: 144, exit_epoch: 934, original_index: 152}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 153}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 154}
+    - {activation_epoch: 972, exit_epoch: 18446744073709551615, original_index: 155}
+    - {activation_epoch: 593, exit_epoch: 928, original_index: 156}
+    - {activation_epoch: 979, exit_epoch: 18446744073709551615, original_index: 157}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 158}
+    - {activation_epoch: 989, exit_epoch: 1897, original_index: 159}
+    - {activation_epoch: 986, exit_epoch: 4153, original_index: 160}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 161}
+    - {activation_epoch: 274, exit_epoch: 1001, original_index: 162}
+    - {activation_epoch: 874, exit_epoch: 982, original_index: 163}
+    - {activation_epoch: 217, exit_epoch: 1000, original_index: 164}
+    - {activation_epoch: 981, exit_epoch: 18446744073709551615, original_index: 165}
+    - {activation_epoch: 996, exit_epoch: 1040, original_index: 166}
+    - {activation_epoch: 72, exit_epoch: 1003, original_index: 167}
+    - {activation_epoch: 1064, exit_epoch: 2109, original_index: 168}
+    - {activation_epoch: 845, exit_epoch: 981, original_index: 169}
+    - {activation_epoch: 1062, exit_epoch: 18446744073709551615, original_index: 170}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 171}
+    - {activation_epoch: 718, exit_epoch: 907, original_index: 172}
+    - {activation_epoch: 994, exit_epoch: 4750, original_index: 173}
+    - {activation_epoch: 1024, exit_epoch: 1419, original_index: 174}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 175}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 176}
+    - {activation_epoch: 988, exit_epoch: 3668, original_index: 177}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 178}
+    - {activation_epoch: 947, exit_epoch: 4177, original_index: 179}
+    - {activation_epoch: 951, exit_epoch: 18446744073709551615, original_index: 180}
+    - {activation_epoch: 632, exit_epoch: 1043, original_index: 181}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 182}
+    - {activation_epoch: 834, exit_epoch: 907, original_index: 183}
+    - {activation_epoch: 1017, exit_epoch: 4564, original_index: 184}
+    - {activation_epoch: 519, exit_epoch: 952, original_index: 185}
+    - {activation_epoch: 1021, exit_epoch: 4747, original_index: 186}
+    - {activation_epoch: 969, exit_epoch: 18446744073709551615, original_index: 187}
+    - {activation_epoch: 275, exit_epoch: 987, original_index: 188}
+    - {activation_epoch: 72, exit_epoch: 966, original_index: 189}
+    - {activation_epoch: 593, exit_epoch: 1034, original_index: 190}
+    - {activation_epoch: 993, exit_epoch: 3437, original_index: 191}
+    - {activation_epoch: 969, exit_epoch: 18446744073709551615, original_index: 192}
+    - {activation_epoch: 951, exit_epoch: 18446744073709551615, original_index: 193}
+    - {activation_epoch: 464, exit_epoch: 1009, original_index: 194}
+    - {activation_epoch: 124, exit_epoch: 1060, original_index: 195}
+    - {activation_epoch: 14, exit_epoch: 975, original_index: 196}
+    - {activation_epoch: 1006, exit_epoch: 1502, original_index: 197}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 198}
+    - {activation_epoch: 968, exit_epoch: 4310, original_index: 199}
+    - {activation_epoch: 1034, exit_epoch: 18446744073709551615, original_index: 200}
+    - {activation_epoch: 993, exit_epoch: 4713, original_index: 201}
+    - {activation_epoch: 437, exit_epoch: 1004, original_index: 202}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 203}
+    - {activation_epoch: 968, exit_epoch: 18446744073709551615, original_index: 204}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 205}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 206}
+    - {activation_epoch: 465, exit_epoch: 986, original_index: 207}
+    - {activation_epoch: 1061, exit_epoch: 4469, original_index: 208}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 209}
+    - {activation_epoch: 931, exit_epoch: 3251, original_index: 210}
+    - {activation_epoch: 846, exit_epoch: 972, original_index: 211}
+    - {activation_epoch: 23, exit_epoch: 984, original_index: 212}
+    - {activation_epoch: 559, exit_epoch: 972, original_index: 213}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 214}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 215}
+    - {activation_epoch: 1014, exit_epoch: 2079, original_index: 216}
+    - {activation_epoch: 33, exit_epoch: 997, original_index: 217}
+    - {activation_epoch: 839, exit_epoch: 1014, original_index: 218}
+    - {activation_epoch: 551, exit_epoch: 1023, original_index: 219}
+    - {activation_epoch: 213, exit_epoch: 981, original_index: 220}
+    - {activation_epoch: 408, exit_epoch: 1011, original_index: 221}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 222}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 223}
+    - {activation_epoch: 553, exit_epoch: 963, original_index: 224}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 225}
+    - {activation_epoch: 666, exit_epoch: 991, original_index: 226}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 227}
+    - {activation_epoch: 433, exit_epoch: 1022, original_index: 228}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 229}
+    - {activation_epoch: 987, exit_epoch: 4052, original_index: 230}
+    - {activation_epoch: 951, exit_epoch: 3914, original_index: 231}
+    - {activation_epoch: 431, exit_epoch: 976, original_index: 232}
+    - {activation_epoch: 902, exit_epoch: 1004, original_index: 233}
+    - {activation_epoch: 165, exit_epoch: 1063, original_index: 234}
+    - {activation_epoch: 1066, exit_epoch: 2293, original_index: 235}
+    - {activation_epoch: 975, exit_epoch: 1042, original_index: 236}
+    - {activation_epoch: 191, exit_epoch: 998, original_index: 237}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 238}
+    - {activation_epoch: 951, exit_epoch: 1014, original_index: 239}
+    - {activation_epoch: 961, exit_epoch: 4952, original_index: 240}
+    - {activation_epoch: 87, exit_epoch: 995, original_index: 241}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 242}
+    - {activation_epoch: 990, exit_epoch: 4555, original_index: 243}
+    - {activation_epoch: 1007, exit_epoch: 1136, original_index: 244}
+    - {activation_epoch: 36, exit_epoch: 985, original_index: 245}
+    - {activation_epoch: 1048, exit_epoch: 4193, original_index: 246}
+    - {activation_epoch: 149, exit_epoch: 1029, original_index: 247}
   output:
-  - - committee: [306, 11]
-      shard: 133
-      total_validator_count: 135
-  - - committee: [296, 343]
-      shard: 134
-      total_validator_count: 135
-  - - committee: [62, 166]
-      shard: 135
-      total_validator_count: 135
-  - - committee: [251, 228]
-      shard: 136
-      total_validator_count: 135
-  - - committee: [180, 114]
-      shard: 137
-      total_validator_count: 135
-  - - committee: [172, 20]
-      shard: 138
-      total_validator_count: 135
-  - - committee: [263, 268]
-      shard: 139
-      total_validator_count: 135
-  - - committee: [80, 212]
-      shard: 140
-      total_validator_count: 135
-  - - committee: [303, 214]
-      shard: 141
-      total_validator_count: 135
-  - - committee: [270, 169, 10]
-      shard: 142
-      total_validator_count: 135
-  - - committee: [231, 21]
-      shard: 143
-      total_validator_count: 135
-  - - committee: [171, 92]
-      shard: 144
-      total_validator_count: 135
-  - - committee: [198, 192]
-      shard: 145
-      total_validator_count: 135
-  - - committee: [232, 86]
-      shard: 146
-      total_validator_count: 135
-  - - committee: [135, 238]
-      shard: 147
-      total_validator_count: 135
-  - - committee: [293, 283]
-      shard: 148
-      total_validator_count: 135
-  - - committee: [137, 332]
-      shard: 149
-      total_validator_count: 135
-  - - committee: [217, 239]
-      shard: 150
-      total_validator_count: 135
-  - - committee: [236, 200, 269]
-      shard: 151
-      total_validator_count: 135
-  - - committee: [151, 209]
-      shard: 152
-      total_validator_count: 135
-  - - committee: [342, 264]
-      shard: 153
-      total_validator_count: 135
-  - - committee: [149, 281]
-      shard: 154
-      total_validator_count: 135
-  - - committee: [97, 235]
-      shard: 155
-      total_validator_count: 135
-  - - committee: [26, 309]
-      shard: 156
-      total_validator_count: 135
-  - - committee: [3, 73]
-      shard: 157
-      total_validator_count: 135
-  - - committee: [116, 82]
-      shard: 158
-      total_validator_count: 135
-  - - committee: [233, 0]
-      shard: 159
-      total_validator_count: 135
-  - - committee: [148, 105, 8]
-      shard: 160
-      total_validator_count: 135
-  - - committee: [145, 164]
-      shard: 161
-      total_validator_count: 135
-  - - committee: [160, 107]
-      shard: 162
-      total_validator_count: 135
-  - - committee: [277, 76]
-      shard: 163
-      total_validator_count: 135
-  - - committee: [215, 307]
-      shard: 164
-      total_validator_count: 135
-  - - committee: [208, 313]
-      shard: 165
-      total_validator_count: 135
-  - - committee: [218, 108]
-      shard: 166
-      total_validator_count: 135
-  - - committee: [338, 340]
-      shard: 167
-      total_validator_count: 135
-  - - committee: [329, 278]
-      shard: 168
-      total_validator_count: 135
-  - - committee: [142, 162, 229]
-      shard: 169
-      total_validator_count: 135
-  - - committee: [61, 243]
-      shard: 170
-      total_validator_count: 135
-  - - committee: [87, 202]
-      shard: 171
-      total_validator_count: 135
-  - - committee: [321, 33]
-      shard: 172
-      total_validator_count: 135
-  - - committee: [96, 253]
-      shard: 173
-      total_validator_count: 135
-  - - committee: [294, 133]
-      shard: 174
-      total_validator_count: 135
-  - - committee: [227, 339]
-      shard: 175
-      total_validator_count: 135
-  - - committee: [14, 318]
-      shard: 176
-      total_validator_count: 135
-  - - committee: [42, 121]
-      shard: 177
-      total_validator_count: 135
-  - - committee: [301, 134, 88]
-      shard: 178
-      total_validator_count: 135
-  - - committee: [271, 349]
-      shard: 179
-      total_validator_count: 135
-  - - committee: [319, 153]
-      shard: 180
-      total_validator_count: 135
-  - - committee: [31, 203]
-      shard: 181
-      total_validator_count: 135
-  - - committee: [189, 204]
-      shard: 182
-      total_validator_count: 135
-  - - committee: [257, 15]
-      shard: 183
-      total_validator_count: 135
-  - - committee: [194, 185]
-      shard: 184
-      total_validator_count: 135
-  - - committee: [246, 168]
-      shard: 185
-      total_validator_count: 135
-  - - committee: [120, 350]
-      shard: 186
-      total_validator_count: 135
-  - - committee: [311, 222, 140]
-      shard: 187
-      total_validator_count: 135
-  - - committee: [74, 165]
-      shard: 188
-      total_validator_count: 135
-  - - committee: [154, 213]
-      shard: 189
-      total_validator_count: 135
-  - - committee: [60, 52]
-      shard: 190
-      total_validator_count: 135
-  - - committee: [347, 320]
-      shard: 191
-      total_validator_count: 135
-  - - committee: [196, 333]
-      shard: 192
-      total_validator_count: 135
-  - - committee: [155, 81]
-      shard: 193
-      total_validator_count: 135
-  - - committee: [5, 55]
-      shard: 194
-      total_validator_count: 135
-  - - committee: [261, 39]
-      shard: 195
-      total_validator_count: 135
-  - - committee: [259, 176, 305]
-      shard: 196
-      total_validator_count: 135
-  seed: '0x1e91ab35b1106e8984dfc0dfa36018004f880b431c2a14f66354bf0192292ffa'
+  - [201]
+  - [50, 202]
+  - [160, 179]
+  - [187]
+  - [117, 195]
+  - [142, 101]
+  - [26, 39]
+  - [99]
+  - [124, 247]
+  - [215, 0]
+  - [218]
+  - [194, 90]
+  - [95, 240]
+  - [167, 190]
+  - [204]
+  - [206, 221]
+  - [230, 82]
+  - [234]
+  - [219, 177]
+  - [28, 233]
+  - [74, 93]
+  - [70]
+  - [32, 59]
+  - [155, 238]
+  - [23]
+  - [231, 36]
+  - [228, 151]
+  - [77, 162]
+  - [119]
+  - [157, 210]
+  - [41, 165]
+  - [1, 84]
+  - [173]
+  - [22, 181]
+  - [104, 166]
+  - [125]
+  - [48, 146]
+  - [129, 57]
+  - [128, 159]
+  - [31]
+  - [79, 102]
+  - [18, 141]
+  - [180]
+  - [25, 88]
+  - [87, 137]
+  - [55, 58]
+  - [3]
+  - [54, 27]
+  - [38, 243]
+  - [43]
+  - [121, 111]
+  - [5, 47]
+  - [81, 143]
+  - [11]
+  - [9, 193]
+  - [126, 139]
+  - [192]
+  - [133, 191]
+  - [24, 135]
+  - [15, 239]
+  - [13]
+  - [105, 64]
+  - [199, 44]
+  - [236, 150]
+  seed: '0xf295ce8921eaca4fc442802e29bf1043ae5b67ae958c5b8b9d16750e472c70ae'
 - input:
-    crosslinking_start_shard: 323
-    validators_status: [0, 3, 2, 3, 2, 2, 2, 2, 4, 3, 1, 1, 2, 3, 1, 1, 2, 0, 2, 2,
-      2, 0, 2, 2, 2, 1, 3, 1, 3, 0, 4, 4, 2, 3, 0, 0, 0, 0, 3, 4, 1, 2, 1, 4, 3, 3,
-      4, 0, 4, 0, 4, 0, 0, 1, 1, 3, 0, 1, 4, 1, 4, 0, 3, 0, 2, 1, 3, 0, 4, 2, 0, 3,
-      0, 3, 4, 4, 2, 0, 4, 4, 1, 2, 0, 4, 3, 2, 0, 1, 1, 4, 2, 3, 3, 3, 3, 2, 2, 3,
-      4, 0, 3, 2, 4, 2, 2, 4, 3, 1, 1, 4, 0, 3, 4, 1, 1, 4, 1, 3, 3, 4, 0, 0, 2, 4,
-      2, 2, 1, 4, 3, 4, 2, 4, 0, 4, 0, 3, 0, 4, 4, 3, 2, 4, 3, 2, 1, 0, 4, 2, 4, 2,
-      2, 4, 3, 0, 0, 2, 0, 3, 3, 4, 2, 3, 2, 4, 2, 4, 4, 1, 4, 3, 4, 3, 0, 1, 4, 4,
-      4, 2, 3, 3, 0, 0, 0, 2, 3, 2, 3, 1, 0, 3, 3, 1, 2, 3, 3, 2, 2, 3, 0, 4, 3, 3,
-      1, 4, 2, 4, 2, 0, 2, 1, 0, 2, 2, 2, 0, 2, 1, 0, 0, 1, 3, 2, 3, 3, 1, 4, 4, 0,
-      1, 3, 2, 3, 0, 2, 0, 4, 4, 3, 1, 3, 3, 4, 0, 0, 0, 1, 0, 3, 0, 3, 1, 0, 0, 2,
-      1, 2, 0, 1, 4, 2, 0, 4, 0, 3, 3, 3, 3, 2, 0, 2, 4, 1, 3, 3, 3, 4, 1, 2, 3, 0,
-      4, 2, 0, 0, 0, 1, 0, 3, 1, 2, 0, 3, 2, 2, 1, 4, 4, 3, 1, 2, 1, 0, 1, 2, 0, 2,
-      0, 4, 0, 0, 1, 0, 1, 4, 2, 4, 3, 2, 0, 3, 2, 3, 2, 4, 1, 4, 2, 1, 0, 0, 1, 4,
-      4, 0, 4, 2, 1, 1, 1, 0, 1, 0, 3, 0, 3, 1, 4, 3, 1, 2, 0, 3, 3, 2, 0, 0, 3, 4,
-      1, 1, 4, 4, 2, 0, 4, 1, 1, 0, 4, 4, 4, 1, 2, 0, 3, 1, 2, 2, 1, 2, 1, 1, 2, 0,
-      3, 0, 2, 0, 4, 3, 4, 1, 0, 2, 4, 4, 3, 3, 0, 2, 3, 2, 2, 3, 4, 2, 2, 3, 3, 4,
-      1, 4, 4, 0, 2, 3, 1, 2, 1, 4, 1, 2, 4, 0, 4, 0, 3, 3, 2, 0, 4]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 0}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 1}
+    - {activation_epoch: 539, exit_epoch: 965, original_index: 2}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 3}
+    - {activation_epoch: 1038, exit_epoch: 1088, original_index: 4}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 5}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 6}
+    - {activation_epoch: 966, exit_epoch: 2719, original_index: 7}
+    - {activation_epoch: 1010, exit_epoch: 2286, original_index: 8}
+    - {activation_epoch: 966, exit_epoch: 2115, original_index: 9}
+    - {activation_epoch: 931, exit_epoch: 1013, original_index: 10}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 11}
+    - {activation_epoch: 1004, exit_epoch: 4565, original_index: 12}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 13}
+    - {activation_epoch: 515, exit_epoch: 1005, original_index: 14}
+    - {activation_epoch: 459, exit_epoch: 989, original_index: 15}
+    - {activation_epoch: 331, exit_epoch: 993, original_index: 16}
+    - {activation_epoch: 107, exit_epoch: 1020, original_index: 17}
+    - {activation_epoch: 50, exit_epoch: 1055, original_index: 18}
+    - {activation_epoch: 24, exit_epoch: 974, original_index: 19}
+    - {activation_epoch: 1, exit_epoch: 1058, original_index: 20}
+    - {activation_epoch: 532, exit_epoch: 990, original_index: 21}
+    - {activation_epoch: 466, exit_epoch: 989, original_index: 22}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 23}
+    - {activation_epoch: 379, exit_epoch: 992, original_index: 24}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 25}
+    - {activation_epoch: 958, exit_epoch: 18446744073709551615, original_index: 26}
+    - {activation_epoch: 1019, exit_epoch: 1284, original_index: 27}
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 28}
+    - {activation_epoch: 1057, exit_epoch: 18446744073709551615, original_index: 29}
+    - {activation_epoch: 559, exit_epoch: 931, original_index: 30}
+    - {activation_epoch: 558, exit_epoch: 1041, original_index: 31}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 32}
+    - {activation_epoch: 1037, exit_epoch: 3948, original_index: 33}
+    - {activation_epoch: 552, exit_epoch: 1022, original_index: 34}
+    - {activation_epoch: 932, exit_epoch: 18446744073709551615, original_index: 35}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 36}
+    - {activation_epoch: 947, exit_epoch: 1827, original_index: 37}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 334, exit_epoch: 925, original_index: 39}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 40}
+    - {activation_epoch: 1003, exit_epoch: 1054, original_index: 41}
+    - {activation_epoch: 1001, exit_epoch: 2444, original_index: 42}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 43}
+    - {activation_epoch: 694, exit_epoch: 962, original_index: 44}
+    - {activation_epoch: 253, exit_epoch: 968, original_index: 45}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 46}
+    - {activation_epoch: 953, exit_epoch: 2038, original_index: 47}
+    - {activation_epoch: 205, exit_epoch: 995, original_index: 48}
+    - {activation_epoch: 648, exit_epoch: 1030, original_index: 49}
+    - {activation_epoch: 1073, exit_epoch: 18446744073709551615, original_index: 50}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 51}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 52}
+    - {activation_epoch: 162, exit_epoch: 998, original_index: 53}
+    - {activation_epoch: 933, exit_epoch: 2983, original_index: 54}
+    - {activation_epoch: 995, exit_epoch: 18446744073709551615, original_index: 55}
+    - {activation_epoch: 563, exit_epoch: 959, original_index: 56}
+    - {activation_epoch: 1000, exit_epoch: 18446744073709551615, original_index: 57}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 58}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 59}
+    - {activation_epoch: 404, exit_epoch: 1001, original_index: 60}
+    - {activation_epoch: 1037, exit_epoch: 18446744073709551615, original_index: 61}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 62}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 63}
+    - {activation_epoch: 922, exit_epoch: 1941, original_index: 64}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 65}
+    - {activation_epoch: 974, exit_epoch: 3656, original_index: 66}
+    - {activation_epoch: 1015, exit_epoch: 1910, original_index: 67}
+    - {activation_epoch: 37, exit_epoch: 1020, original_index: 68}
+    - {activation_epoch: 353, exit_epoch: 1035, original_index: 69}
+    - {activation_epoch: 519, exit_epoch: 987, original_index: 70}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 71}
+    - {activation_epoch: 411, exit_epoch: 1027, original_index: 72}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 73}
+    - {activation_epoch: 1018, exit_epoch: 18446744073709551615, original_index: 74}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 75}
+    - {activation_epoch: 1037, exit_epoch: 2628, original_index: 76}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 77}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 78}
+    - {activation_epoch: 112, exit_epoch: 958, original_index: 79}
+    - {activation_epoch: 983, exit_epoch: 4390, original_index: 80}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 956, exit_epoch: 4074, original_index: 82}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 83}
+    - {activation_epoch: 1023, exit_epoch: 4194, original_index: 84}
+    - {activation_epoch: 997, exit_epoch: 3479, original_index: 85}
+    - {activation_epoch: 1042, exit_epoch: 18446744073709551615, original_index: 86}
+    - {activation_epoch: 969, exit_epoch: 18446744073709551615, original_index: 87}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 88}
+    - {activation_epoch: 109, exit_epoch: 1019, original_index: 89}
+    - {activation_epoch: 959, exit_epoch: 18446744073709551615, original_index: 90}
+    - {activation_epoch: 374, exit_epoch: 1044, original_index: 91}
+    - {activation_epoch: 982, exit_epoch: 3067, original_index: 92}
+    - {activation_epoch: 999, exit_epoch: 3228, original_index: 93}
+    - {activation_epoch: 954, exit_epoch: 18446744073709551615, original_index: 94}
+    - {activation_epoch: 859, exit_epoch: 1011, original_index: 95}
+    - {activation_epoch: 999, exit_epoch: 4277, original_index: 96}
+    - {activation_epoch: 941, exit_epoch: 18446744073709551615, original_index: 97}
+    - {activation_epoch: 1039, exit_epoch: 4739, original_index: 98}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 99}
+    - {activation_epoch: 961, exit_epoch: 1011, original_index: 100}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 101}
+    - {activation_epoch: 579, exit_epoch: 940, original_index: 102}
+    - {activation_epoch: 973, exit_epoch: 18446744073709551615, original_index: 103}
+    - {activation_epoch: 759, exit_epoch: 1008, original_index: 104}
+    - {activation_epoch: 965, exit_epoch: 2793, original_index: 105}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 106}
+    - {activation_epoch: 114, exit_epoch: 985, original_index: 107}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 108}
+    - {activation_epoch: 836, exit_epoch: 947, original_index: 109}
+    - {activation_epoch: 986, exit_epoch: 4685, original_index: 110}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 111}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 112}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 113}
+    - {activation_epoch: 648, exit_epoch: 980, original_index: 114}
+    - {activation_epoch: 335, exit_epoch: 1032, original_index: 115}
+    - {activation_epoch: 1049, exit_epoch: 18446744073709551615, original_index: 116}
+    - {activation_epoch: 113, exit_epoch: 973, original_index: 117}
+    - {activation_epoch: 544, exit_epoch: 981, original_index: 118}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 119}
+    - {activation_epoch: 834, exit_epoch: 1019, original_index: 120}
+    - {activation_epoch: 112, exit_epoch: 1058, original_index: 121}
+    - {activation_epoch: 931, exit_epoch: 18446744073709551615, original_index: 122}
+    - {activation_epoch: 611, exit_epoch: 1037, original_index: 123}
+    - {activation_epoch: 874, exit_epoch: 1021, original_index: 124}
+    - {activation_epoch: 530, exit_epoch: 970, original_index: 125}
+    - {activation_epoch: 1019, exit_epoch: 3074, original_index: 126}
+    - {activation_epoch: 852, exit_epoch: 1002, original_index: 127}
+    - {activation_epoch: 885, exit_epoch: 961, original_index: 128}
+    - {activation_epoch: 1000, exit_epoch: 18446744073709551615, original_index: 129}
+    - {activation_epoch: 383, exit_epoch: 951, original_index: 130}
+    - {activation_epoch: 1053, exit_epoch: 18446744073709551615, original_index: 131}
+    - {activation_epoch: 947, exit_epoch: 990, original_index: 132}
+    - {activation_epoch: 1029, exit_epoch: 4536, original_index: 133}
+    - {activation_epoch: 1049, exit_epoch: 4714, original_index: 134}
+    - {activation_epoch: 767, exit_epoch: 966, original_index: 135}
+    - {activation_epoch: 971, exit_epoch: 4426, original_index: 136}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 137}
+    - {activation_epoch: 105, exit_epoch: 962, original_index: 138}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 139}
+    - {activation_epoch: 1050, exit_epoch: 4968, original_index: 140}
+    - {activation_epoch: 993, exit_epoch: 4567, original_index: 141}
+    - {activation_epoch: 65, exit_epoch: 977, original_index: 142}
+    - {activation_epoch: 7, exit_epoch: 1024, original_index: 143}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 144}
+    - {activation_epoch: 585, exit_epoch: 1003, original_index: 145}
+    - {activation_epoch: 986, exit_epoch: 18446744073709551615, original_index: 146}
+    - {activation_epoch: 495, exit_epoch: 994, original_index: 147}
+    - {activation_epoch: 294, exit_epoch: 1023, original_index: 148}
+    - {activation_epoch: 954, exit_epoch: 18446744073709551615, original_index: 149}
+    - {activation_epoch: 570, exit_epoch: 1024, original_index: 150}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 151}
+    - {activation_epoch: 183, exit_epoch: 1051, original_index: 152}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 153}
+    - {activation_epoch: 1060, exit_epoch: 18446744073709551615, original_index: 154}
+    - {activation_epoch: 716, exit_epoch: 999, original_index: 155}
+    - {activation_epoch: 938, exit_epoch: 1777, original_index: 156}
+    - {activation_epoch: 1040, exit_epoch: 18446744073709551615, original_index: 157}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 158}
+    - {activation_epoch: 196, exit_epoch: 990, original_index: 159}
+    - {activation_epoch: 1060, exit_epoch: 3543, original_index: 160}
+    - {activation_epoch: 984, exit_epoch: 4791, original_index: 161}
+    - {activation_epoch: 142, exit_epoch: 986, original_index: 162}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 163}
+    - {activation_epoch: 431, exit_epoch: 1024, original_index: 164}
+    - {activation_epoch: 198, exit_epoch: 1065, original_index: 165}
+    - {activation_epoch: 633, exit_epoch: 1019, original_index: 166}
+    - {activation_epoch: 671, exit_epoch: 1003, original_index: 167}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 168}
+    - {activation_epoch: 960, exit_epoch: 18446744073709551615, original_index: 169}
+    - {activation_epoch: 577, exit_epoch: 1019, original_index: 170}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 171}
+    - {activation_epoch: 996, exit_epoch: 18446744073709551615, original_index: 172}
+    - {activation_epoch: 347, exit_epoch: 936, original_index: 173}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 174}
+    - {activation_epoch: 995, exit_epoch: 18446744073709551615, original_index: 175}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 176}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 177}
+    - {activation_epoch: 1050, exit_epoch: 18446744073709551615, original_index: 178}
+    - {activation_epoch: 999, exit_epoch: 1878, original_index: 179}
+    - {activation_epoch: 77, exit_epoch: 1004, original_index: 180}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 181}
+    - {activation_epoch: 476, exit_epoch: 940, original_index: 182}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 183}
+    - {activation_epoch: 368, exit_epoch: 1025, original_index: 184}
+    - {activation_epoch: 1005, exit_epoch: 1015, original_index: 185}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 186}
+    - {activation_epoch: 390, exit_epoch: 1035, original_index: 187}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 188}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 189}
+    - {activation_epoch: 993, exit_epoch: 1035, original_index: 190}
+    - {activation_epoch: 965, exit_epoch: 991, original_index: 191}
+    - {activation_epoch: 671, exit_epoch: 971, original_index: 192}
+    - {activation_epoch: 932, exit_epoch: 4481, original_index: 193}
+    - {activation_epoch: 704, exit_epoch: 1020, original_index: 194}
   output:
-  - - committee: [299, 42]
-      shard: 323
-      total_validator_count: 164
-  - - committee: [381, 366, 144]
-      shard: 324
-      total_validator_count: 164
-  - - committee: [380, 143]
-      shard: 325
-      total_validator_count: 164
-  - - committee: [122, 155, 294]
-      shard: 326
-      total_validator_count: 164
-  - - committee: [11, 23]
-      shard: 327
-      total_validator_count: 164
-  - - committee: [420, 353, 24]
-      shard: 328
-      total_validator_count: 164
-  - - committee: [405, 358]
-      shard: 329
-      total_validator_count: 164
-  - - committee: [6, 113, 402]
-      shard: 330
-      total_validator_count: 164
-  - - committee: [95, 10, 414]
-      shard: 331
-      total_validator_count: 164
-  - - committee: [212, 417]
-      shard: 332
-      total_validator_count: 164
-  - - committee: [285, 124, 349]
-      shard: 333
-      total_validator_count: 164
-  - - committee: [281, 254]
-      shard: 334
-      total_validator_count: 164
-  - - committee: [185, 25, 216]
-      shard: 335
-      total_validator_count: 164
-  - - committee: [371, 406]
-      shard: 336
-      total_validator_count: 164
-  - - committee: [230, 276, 310]
-      shard: 337
-      total_validator_count: 164
-  - - committee: [32, 64, 192]
-      shard: 338
-      total_validator_count: 164
-  - - committee: [87, 191]
-      shard: 339
-      total_validator_count: 164
-  - - committee: [2, 300, 391]
-      shard: 340
-      total_validator_count: 164
-  - - committee: [314, 320]
-      shard: 341
-      total_validator_count: 164
-  - - committee: [340, 162, 164]
-      shard: 342
-      total_validator_count: 164
-  - - committee: [393, 255]
-      shard: 343
-      total_validator_count: 164
-  - - committee: [40, 421, 238]
-      shard: 344
-      total_validator_count: 164
-  - - committee: [114, 208]
-      shard: 345
-      total_validator_count: 164
-  - - committee: [81, 365, 104]
-      shard: 346
-      total_validator_count: 164
-  - - committee: [277, 359, 377]
-      shard: 347
-      total_validator_count: 164
-  - - committee: [345, 150]
-      shard: 348
-      total_validator_count: 164
-  - - committee: [372, 386, 330]
-      shard: 349
-      total_validator_count: 164
-  - - committee: [269, 22]
-      shard: 350
-      total_validator_count: 164
-  - - committee: [196, 7, 375]
-      shard: 351
-      total_validator_count: 164
-  - - committee: [418, 206]
-      shard: 352
-      total_validator_count: 164
-  - - committee: [257, 298, 20]
-      shard: 353
-      total_validator_count: 164
-  - - committee: [376, 14, 317]
-      shard: 354
-      total_validator_count: 164
-  - - committee: [303, 80]
-      shard: 355
-      total_validator_count: 164
-  - - committee: [324, 213, 271]
-      shard: 356
-      total_validator_count: 164
-  - - committee: [219, 160]
-      shard: 357
-      total_validator_count: 164
-  - - committee: [378, 428, 228]
-      shard: 358
-      total_validator_count: 164
-  - - committee: [27, 224]
-      shard: 359
-      total_validator_count: 164
-  - - committee: [116, 167, 410]
-      shard: 360
-      total_validator_count: 164
-  - - committee: [335, 59]
-      shard: 361
-      total_validator_count: 164
-  - - committee: [76, 288, 259]
-      shard: 362
-      total_validator_count: 164
-  - - committee: [88, 253, 327]
-      shard: 363
-      total_validator_count: 164
-  - - committee: [85, 90]
-      shard: 364
-      total_validator_count: 164
-  - - committee: [57, 202, 348]
-      shard: 365
-      total_validator_count: 164
-  - - committee: [177, 233]
-      shard: 366
-      total_validator_count: 164
-  - - committee: [54, 41, 379]
-      shard: 367
-      total_validator_count: 164
-  - - committee: [305, 126]
-      shard: 368
-      total_validator_count: 164
-  - - committee: [416, 267, 101]
-      shard: 369
-      total_validator_count: 164
-  - - committee: [173, 147, 326]
-      shard: 370
-      total_validator_count: 164
-  - - committee: [183, 211]
-      shard: 371
-      total_validator_count: 164
-  - - committee: [130, 4, 16]
-      shard: 372
-      total_validator_count: 164
-  - - committee: [187, 215]
-      shard: 373
-      total_validator_count: 164
-  - - committee: [245, 302, 18]
-      shard: 374
-      total_validator_count: 164
-  - - committee: [204, 65]
-      shard: 375
-      total_validator_count: 164
-  - - committee: [125, 338, 362]
-      shard: 376
-      total_validator_count: 164
-  - - committee: [221, 107]
-      shard: 377
-      total_validator_count: 164
-  - - committee: [19, 289, 337]
-      shard: 378
-      total_validator_count: 164
-  - - committee: [5, 195, 15]
-      shard: 379
-      total_validator_count: 164
-  - - committee: [401, 293]
-      shard: 380
-      total_validator_count: 164
-  - - committee: [209, 149, 69]
-      shard: 381
-      total_validator_count: 164
-  - - committee: [12, 322]
-      shard: 382
-      total_validator_count: 164
-  - - committee: [382, 250, 312]
-      shard: 383
-      total_validator_count: 164
-  - - committee: [336, 108]
-      shard: 384
-      total_validator_count: 164
-  - - committee: [103, 140, 96]
-      shard: 385
-      total_validator_count: 164
-  - - committee: [399, 53, 292]
-      shard: 386
-      total_validator_count: 164
-  seed: '0x3e0145d6c946e5121aa6a8f761d1647d093fb976f2497361897012dfa6dc0190'
+  - [122]
+  - [87]
+  - [20]
+  - [143, 141]
+  - [187]
+  - [150]
+  - [164, 120]
+  - [175]
+  - [129]
+  - [184]
+  - [72, 10]
+  - [71]
+  - [166]
+  - [85, 110]
+  - [14]
+  - [94]
+  - [25, 167]
+  - [156]
+  - [37]
+  - [91]
+  - [152, 90]
+  - [96]
+  - [105]
+  - [103, 68]
+  - [121]
+  - [145]
+  - [35, 65]
+  - [127]
+  - [136]
+  - [47]
+  - [89, 165]
+  - [82]
+  - [64]
+  - [1, 7]
+  - [92]
+  - [57]
+  - [34]
+  - [161, 149]
+  - [123]
+  - [66]
+  - [18, 188]
+  - [124]
+  - [146]
+  - [190, 189]
+  - [69]
+  - [54]
+  - [180]
+  - [80, 194]
+  - [9]
+  - [139]
+  - [112, 93]
+  - [179]
+  - [104]
+  - [169, 55]
+  - [148]
+  - [60]
+  - [31]
+  - [49, 170]
+  - [115]
+  - [193]
+  - [172, 97]
+  - [17]
+  - [26]
+  - [95, 100]
+  seed: '0x2d51968fe94a878920dbf9e095ea949e2cd13eb46ac3130607a1344c203bf6df'
 - input:
-    crosslinking_start_shard: 233
-    validators_status: [3, 0, 1, 3, 3, 2, 4, 2, 4, 4, 2, 4, 2, 1, 1, 2, 2, 1, 4, 2,
-      1, 2, 3, 4, 3, 1, 0, 1, 0, 4, 4, 0, 3, 3, 1, 2, 4, 4, 1, 3, 4, 2, 2, 3, 4, 4,
-      3, 1, 3, 0, 3, 0, 2, 4, 1, 2, 4, 1, 2, 2, 1, 3, 3, 3, 1, 1, 3, 3, 2, 2, 0, 4,
-      4, 1, 4, 1, 4, 0, 4, 2, 2, 4, 4, 0, 1, 1, 1, 2, 1, 2, 1, 2, 2, 3, 1, 0, 0, 0,
-      0, 4, 2, 4, 0, 3, 2, 2, 4, 3, 3, 3, 1, 0, 2, 4, 2, 2, 4, 2, 4, 3, 1, 0, 0, 3,
-      2, 0, 1, 4, 3, 2, 1, 1, 0, 4, 3, 2, 1, 0, 1, 4, 2, 3, 0, 3, 0, 0, 4, 0, 4, 1,
-      0, 2, 3, 2, 4, 2, 1, 1, 3, 2, 4, 4, 2, 1, 1, 0, 0, 4, 4, 1, 0, 1, 0, 3, 4, 3,
-      0, 0, 2, 4, 1, 1, 3, 0, 4, 0, 4, 0, 3, 0, 2, 2, 4, 1, 1, 2, 4, 0, 3, 4, 1, 4,
-      2, 3, 2, 1, 3, 0, 1, 0, 3, 1, 2, 1, 4, 2, 1, 3, 0, 4, 2, 2, 0, 1, 2, 3, 4, 2,
-      2, 2, 2, 4, 0, 1, 1, 2, 1, 4, 1, 0, 1, 4, 3, 1, 2, 3, 0, 2, 3, 3, 4, 2, 4, 4,
-      0, 0, 2, 3, 4, 1, 2, 2, 2, 1, 4, 4, 0, 3, 2, 0, 0, 1, 3, 4, 2, 4, 4, 2, 0, 0,
-      3, 4, 1, 4, 0, 0, 1, 0, 3, 2, 1, 3, 1, 1, 1, 2, 0, 4, 3, 1, 3, 1, 0, 4, 1, 4,
-      1, 3, 2, 3, 2, 1, 2, 0, 3, 2, 1, 1, 1, 0, 2, 2, 2, 0, 2, 0, 2, 3, 1, 3, 3, 3,
-      1, 2, 3, 0, 0, 2, 1, 2, 1, 4, 2, 1, 1, 3, 4, 1, 0, 3, 0, 3, 2, 2, 1, 3, 3, 4,
-      0, 2, 4, 1, 2, 1, 4, 3, 0, 2, 3, 0, 2, 0, 3, 0, 0, 0, 2, 4, 4, 3, 4, 3, 2, 0,
-      0, 1, 2, 2, 4, 0, 0, 1, 3, 3, 3, 4, 4, 3, 4, 0, 4, 3, 1, 4, 0, 1, 3, 0, 4, 0,
-      0, 3, 0, 2, 0, 4, 3, 0, 0, 1, 3, 4, 3, 1, 2, 4, 0, 4, 0, 0, 0, 4, 3, 4, 2, 3,
-      2, 3, 4, 4, 1, 4, 1, 1, 3, 2, 3, 0, 4, 1, 4, 4, 4, 3, 1, 4, 4, 2, 0, 1, 3, 3,
-      2, 4, 1, 0, 2, 4, 4, 1, 2, 1, 4, 2, 0, 2, 1, 0, 3, 1, 0, 3, 0, 0]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 0}
+    - {activation_epoch: 1016, exit_epoch: 1024, original_index: 1}
+    - {activation_epoch: 993, exit_epoch: 1293, original_index: 2}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 3}
+    - {activation_epoch: 995, exit_epoch: 18446744073709551615, original_index: 4}
+    - {activation_epoch: 1071, exit_epoch: 1252, original_index: 5}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 6}
+    - {activation_epoch: 994, exit_epoch: 4886, original_index: 7}
+    - {activation_epoch: 953, exit_epoch: 18446744073709551615, original_index: 8}
+    - {activation_epoch: 328, exit_epoch: 1010, original_index: 9}
+    - {activation_epoch: 1067, exit_epoch: 4305, original_index: 10}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 11}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 12}
+    - {activation_epoch: 730, exit_epoch: 972, original_index: 13}
+    - {activation_epoch: 907, exit_epoch: 1038, original_index: 14}
+    - {activation_epoch: 986, exit_epoch: 18446744073709551615, original_index: 15}
+    - {activation_epoch: 997, exit_epoch: 18446744073709551615, original_index: 16}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 17}
+    - {activation_epoch: 690, exit_epoch: 1020, original_index: 18}
+    - {activation_epoch: 990, exit_epoch: 1090, original_index: 19}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 20}
+    - {activation_epoch: 824, exit_epoch: 1017, original_index: 21}
+    - {activation_epoch: 981, exit_epoch: 4944, original_index: 22}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 23}
+    - {activation_epoch: 739, exit_epoch: 988, original_index: 24}
+    - {activation_epoch: 995, exit_epoch: 18446744073709551615, original_index: 25}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 26}
+    - {activation_epoch: 1033, exit_epoch: 18446744073709551615, original_index: 27}
+    - {activation_epoch: 157, exit_epoch: 1063, original_index: 28}
+    - {activation_epoch: 282, exit_epoch: 1016, original_index: 29}
+    - {activation_epoch: 231, exit_epoch: 979, original_index: 30}
+    - {activation_epoch: 963, exit_epoch: 3664, original_index: 31}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 32}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 33}
+    - {activation_epoch: 837, exit_epoch: 919, original_index: 34}
+    - {activation_epoch: 720, exit_epoch: 1036, original_index: 35}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 36}
+    - {activation_epoch: 953, exit_epoch: 18446744073709551615, original_index: 37}
+    - {activation_epoch: 475, exit_epoch: 982, original_index: 38}
+    - {activation_epoch: 995, exit_epoch: 4118, original_index: 39}
+    - {activation_epoch: 967, exit_epoch: 2249, original_index: 40}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 41}
+    - {activation_epoch: 643, exit_epoch: 977, original_index: 42}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 43}
+    - {activation_epoch: 1010, exit_epoch: 4424, original_index: 44}
+    - {activation_epoch: 963, exit_epoch: 1032, original_index: 45}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 46}
+    - {activation_epoch: 969, exit_epoch: 4320, original_index: 47}
+    - {activation_epoch: 1064, exit_epoch: 18446744073709551615, original_index: 48}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 49}
+    - {activation_epoch: 25, exit_epoch: 958, original_index: 50}
+    - {activation_epoch: 742, exit_epoch: 1085, original_index: 51}
+    - {activation_epoch: 43, exit_epoch: 1020, original_index: 52}
+    - {activation_epoch: 1015, exit_epoch: 18446744073709551615, original_index: 53}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 54}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 55}
+    - {activation_epoch: 768, exit_epoch: 967, original_index: 56}
+    - {activation_epoch: 754, exit_epoch: 978, original_index: 57}
+    - {activation_epoch: 995, exit_epoch: 1743, original_index: 58}
+    - {activation_epoch: 346, exit_epoch: 992, original_index: 59}
+    - {activation_epoch: 997, exit_epoch: 1476, original_index: 60}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 61}
+    - {activation_epoch: 24, exit_epoch: 1067, original_index: 62}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 63}
+    - {activation_epoch: 956, exit_epoch: 1017, original_index: 64}
+    - {activation_epoch: 612, exit_epoch: 1085, original_index: 65}
+    - {activation_epoch: 106, exit_epoch: 1054, original_index: 66}
+    - {activation_epoch: 995, exit_epoch: 18446744073709551615, original_index: 67}
+    - {activation_epoch: 909, exit_epoch: 943, original_index: 68}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 69}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 70}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 71}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 72}
+    - {activation_epoch: 475, exit_epoch: 1020, original_index: 73}
+    - {activation_epoch: 1030, exit_epoch: 18446744073709551615, original_index: 74}
+    - {activation_epoch: 1029, exit_epoch: 18446744073709551615, original_index: 75}
+    - {activation_epoch: 409, exit_epoch: 1028, original_index: 76}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 77}
+    - {activation_epoch: 312, exit_epoch: 975, original_index: 78}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 79}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 80}
+    - {activation_epoch: 970, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 99, exit_epoch: 1026, original_index: 82}
+    - {activation_epoch: 221, exit_epoch: 1005, original_index: 83}
+    - {activation_epoch: 1042, exit_epoch: 18446744073709551615, original_index: 84}
+    - {activation_epoch: 934, exit_epoch: 18446744073709551615, original_index: 85}
+    - {activation_epoch: 996, exit_epoch: 18446744073709551615, original_index: 86}
+    - {activation_epoch: 985, exit_epoch: 1009, original_index: 87}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 88}
+    - {activation_epoch: 67, exit_epoch: 996, original_index: 89}
+    - {activation_epoch: 828, exit_epoch: 1006, original_index: 90}
+    - {activation_epoch: 324, exit_epoch: 999, original_index: 91}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 92}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 93}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 94}
+    - {activation_epoch: 202, exit_epoch: 973, original_index: 95}
+    - {activation_epoch: 999, exit_epoch: 1374, original_index: 96}
+    - {activation_epoch: 1037, exit_epoch: 18446744073709551615, original_index: 97}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 98}
+    - {activation_epoch: 971, exit_epoch: 18446744073709551615, original_index: 99}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 100}
+    - {activation_epoch: 1001, exit_epoch: 1507, original_index: 101}
+    - {activation_epoch: 788, exit_epoch: 951, original_index: 102}
+    - {activation_epoch: 947, exit_epoch: 1078, original_index: 103}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 104}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 105}
+    - {activation_epoch: 1015, exit_epoch: 4775, original_index: 106}
+    - {activation_epoch: 1015, exit_epoch: 18446744073709551615, original_index: 107}
+    - {activation_epoch: 11, exit_epoch: 960, original_index: 108}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 109}
+    - {activation_epoch: 104, exit_epoch: 985, original_index: 110}
+    - {activation_epoch: 402, exit_epoch: 1015, original_index: 111}
+    - {activation_epoch: 1025, exit_epoch: 2487, original_index: 112}
+    - {activation_epoch: 29, exit_epoch: 959, original_index: 113}
+    - {activation_epoch: 1063, exit_epoch: 18446744073709551615, original_index: 114}
+    - {activation_epoch: 868, exit_epoch: 976, original_index: 115}
+    - {activation_epoch: 1065, exit_epoch: 3176, original_index: 116}
+    - {activation_epoch: 193, exit_epoch: 997, original_index: 117}
+    - {activation_epoch: 932, exit_epoch: 972, original_index: 118}
+    - {activation_epoch: 372, exit_epoch: 1012, original_index: 119}
+    - {activation_epoch: 472, exit_epoch: 1015, original_index: 120}
+    - {activation_epoch: 392, exit_epoch: 1043, original_index: 121}
+    - {activation_epoch: 974, exit_epoch: 2738, original_index: 122}
+    - {activation_epoch: 481, exit_epoch: 1058, original_index: 123}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 124}
+    - {activation_epoch: 897, exit_epoch: 966, original_index: 125}
+    - {activation_epoch: 813, exit_epoch: 1055, original_index: 126}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 127}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 128}
+    - {activation_epoch: 921, exit_epoch: 1024, original_index: 129}
+    - {activation_epoch: 1041, exit_epoch: 3280, original_index: 130}
+    - {activation_epoch: 854, exit_epoch: 982, original_index: 131}
+    - {activation_epoch: 960, exit_epoch: 18446744073709551615, original_index: 132}
+    - {activation_epoch: 982, exit_epoch: 1144, original_index: 133}
+    - {activation_epoch: 1034, exit_epoch: 18446744073709551615, original_index: 134}
+    - {activation_epoch: 528, exit_epoch: 996, original_index: 135}
+    - {activation_epoch: 1019, exit_epoch: 4175, original_index: 136}
+    - {activation_epoch: 1039, exit_epoch: 4844, original_index: 137}
+    - {activation_epoch: 1048, exit_epoch: 3714, original_index: 138}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 139}
+    - {activation_epoch: 942, exit_epoch: 18446744073709551615, original_index: 140}
+    - {activation_epoch: 951, exit_epoch: 18446744073709551615, original_index: 141}
+    - {activation_epoch: 1094, exit_epoch: 18446744073709551615, original_index: 142}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 143}
+    - {activation_epoch: 558, exit_epoch: 999, original_index: 144}
+    - {activation_epoch: 913, exit_epoch: 18446744073709551615, original_index: 145}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 146}
+    - {activation_epoch: 760, exit_epoch: 951, original_index: 147}
+    - {activation_epoch: 992, exit_epoch: 4338, original_index: 148}
+    - {activation_epoch: 968, exit_epoch: 998, original_index: 149}
+    - {activation_epoch: 1100, exit_epoch: 1701, original_index: 150}
+    - {activation_epoch: 481, exit_epoch: 975, original_index: 151}
+    - {activation_epoch: 1031, exit_epoch: 18446744073709551615, original_index: 152}
+    - {activation_epoch: 990, exit_epoch: 2659, original_index: 153}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 154}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 155}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 156}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 157}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 158}
+    - {activation_epoch: 1049, exit_epoch: 3703, original_index: 159}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 160}
+    - {activation_epoch: 971, exit_epoch: 1016, original_index: 161}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 162}
+    - {activation_epoch: 386, exit_epoch: 987, original_index: 163}
+    - {activation_epoch: 966, exit_epoch: 3158, original_index: 164}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 165}
+    - {activation_epoch: 919, exit_epoch: 1003, original_index: 166}
+    - {activation_epoch: 497, exit_epoch: 980, original_index: 167}
+    - {activation_epoch: 974, exit_epoch: 18446744073709551615, original_index: 168}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 169}
+    - {activation_epoch: 349, exit_epoch: 1004, original_index: 170}
+    - {activation_epoch: 89, exit_epoch: 1030, original_index: 171}
+    - {activation_epoch: 744, exit_epoch: 958, original_index: 172}
+    - {activation_epoch: 1018, exit_epoch: 1088, original_index: 173}
+    - {activation_epoch: 221, exit_epoch: 996, original_index: 174}
+    - {activation_epoch: 127, exit_epoch: 951, original_index: 175}
+    - {activation_epoch: 1001, exit_epoch: 3695, original_index: 176}
+    - {activation_epoch: 555, exit_epoch: 1001, original_index: 177}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 178}
+    - {activation_epoch: 1011, exit_epoch: 2069, original_index: 179}
+    - {activation_epoch: 458, exit_epoch: 1024, original_index: 180}
+    - {activation_epoch: 103, exit_epoch: 976, original_index: 181}
+    - {activation_epoch: 932, exit_epoch: 2131, original_index: 182}
+    - {activation_epoch: 1072, exit_epoch: 18446744073709551615, original_index: 183}
+    - {activation_epoch: 1022, exit_epoch: 18446744073709551615, original_index: 184}
+    - {activation_epoch: 978, exit_epoch: 992, original_index: 185}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 186}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 187}
+    - {activation_epoch: 279, exit_epoch: 980, original_index: 188}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 189}
+    - {activation_epoch: 830, exit_epoch: 1015, original_index: 190}
+    - {activation_epoch: 1030, exit_epoch: 2807, original_index: 191}
+    - {activation_epoch: 547, exit_epoch: 1037, original_index: 192}
+    - {activation_epoch: 957, exit_epoch: 18446744073709551615, original_index: 193}
+    - {activation_epoch: 988, exit_epoch: 18446744073709551615, original_index: 194}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 195}
+    - {activation_epoch: 879, exit_epoch: 994, original_index: 196}
+    - {activation_epoch: 819, exit_epoch: 1021, original_index: 197}
+    - {activation_epoch: 970, exit_epoch: 2918, original_index: 198}
+    - {activation_epoch: 943, exit_epoch: 18446744073709551615, original_index: 199}
+    - {activation_epoch: 870, exit_epoch: 1049, original_index: 200}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 201}
+    - {activation_epoch: 270, exit_epoch: 1052, original_index: 202}
+    - {activation_epoch: 623, exit_epoch: 1024, original_index: 203}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 204}
+    - {activation_epoch: 869, exit_epoch: 973, original_index: 205}
+    - {activation_epoch: 312, exit_epoch: 987, original_index: 206}
+    - {activation_epoch: 1023, exit_epoch: 3647, original_index: 207}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 208}
+    - {activation_epoch: 782, exit_epoch: 976, original_index: 209}
+    - {activation_epoch: 1018, exit_epoch: 3585, original_index: 210}
+    - {activation_epoch: 855, exit_epoch: 1022, original_index: 211}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 212}
+    - {activation_epoch: 960, exit_epoch: 3944, original_index: 213}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 214}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 215}
+    - {activation_epoch: 508, exit_epoch: 1056, original_index: 216}
+    - {activation_epoch: 802, exit_epoch: 1032, original_index: 217}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 218}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 219}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 220}
+    - {activation_epoch: 222, exit_epoch: 1053, original_index: 221}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 222}
+    - {activation_epoch: 928, exit_epoch: 1009, original_index: 223}
+    - {activation_epoch: 98, exit_epoch: 1004, original_index: 224}
+    - {activation_epoch: 778, exit_epoch: 964, original_index: 225}
+    - {activation_epoch: 874, exit_epoch: 990, original_index: 226}
+    - {activation_epoch: 102, exit_epoch: 942, original_index: 227}
+    - {activation_epoch: 466, exit_epoch: 946, original_index: 228}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 229}
+    - {activation_epoch: 1062, exit_epoch: 18446744073709551615, original_index: 230}
+    - {activation_epoch: 262, exit_epoch: 1053, original_index: 231}
+    - {activation_epoch: 288, exit_epoch: 993, original_index: 232}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 233}
+    - {activation_epoch: 1002, exit_epoch: 18446744073709551615, original_index: 234}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 235}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 236}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 237}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 238}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 239}
+    - {activation_epoch: 159, exit_epoch: 1000, original_index: 240}
+    - {activation_epoch: 1040, exit_epoch: 3317, original_index: 241}
+    - {activation_epoch: 656, exit_epoch: 1034, original_index: 242}
+    - {activation_epoch: 682, exit_epoch: 1031, original_index: 243}
+    - {activation_epoch: 429, exit_epoch: 945, original_index: 244}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 245}
+    - {activation_epoch: 293, exit_epoch: 962, original_index: 246}
+    - {activation_epoch: 991, exit_epoch: 3350, original_index: 247}
+    - {activation_epoch: 686, exit_epoch: 987, original_index: 248}
+    - {activation_epoch: 582, exit_epoch: 959, original_index: 249}
+    - {activation_epoch: 85, exit_epoch: 960, original_index: 250}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 251}
+    - {activation_epoch: 307, exit_epoch: 1011, original_index: 252}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 253}
+    - {activation_epoch: 923, exit_epoch: 18446744073709551615, original_index: 254}
+    - {activation_epoch: 890, exit_epoch: 1055, original_index: 255}
+    - {activation_epoch: 958, exit_epoch: 18446744073709551615, original_index: 256}
+    - {activation_epoch: 991, exit_epoch: 18446744073709551615, original_index: 257}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 258}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 259}
+    - {activation_epoch: 879, exit_epoch: 999, original_index: 260}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 261}
+    - {activation_epoch: 594, exit_epoch: 940, original_index: 262}
+    - {activation_epoch: 1004, exit_epoch: 2815, original_index: 263}
+    - {activation_epoch: 304, exit_epoch: 1027, original_index: 264}
+    - {activation_epoch: 1016, exit_epoch: 3733, original_index: 265}
+    - {activation_epoch: 979, exit_epoch: 1068, original_index: 266}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 267}
+    - {activation_epoch: 1012, exit_epoch: 2179, original_index: 268}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 269}
+    - {activation_epoch: 790, exit_epoch: 990, original_index: 270}
+    - {activation_epoch: 121, exit_epoch: 1025, original_index: 271}
+    - {activation_epoch: 302, exit_epoch: 1030, original_index: 272}
+    - {activation_epoch: 819, exit_epoch: 993, original_index: 273}
+    - {activation_epoch: 996, exit_epoch: 18446744073709551615, original_index: 274}
+    - {activation_epoch: 693, exit_epoch: 1000, original_index: 275}
+    - {activation_epoch: 908, exit_epoch: 18446744073709551615, original_index: 276}
+    - {activation_epoch: 840, exit_epoch: 993, original_index: 277}
+    - {activation_epoch: 988, exit_epoch: 3658, original_index: 278}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 279}
+    - {activation_epoch: 1015, exit_epoch: 18446744073709551615, original_index: 280}
+    - {activation_epoch: 287, exit_epoch: 1032, original_index: 281}
+    - {activation_epoch: 428, exit_epoch: 1017, original_index: 282}
+    - {activation_epoch: 961, exit_epoch: 18446744073709551615, original_index: 283}
+    - {activation_epoch: 996, exit_epoch: 3820, original_index: 284}
+    - {activation_epoch: 777, exit_epoch: 942, original_index: 285}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 286}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 287}
+    - {activation_epoch: 931, exit_epoch: 18446744073709551615, original_index: 288}
+    - {activation_epoch: 143, exit_epoch: 937, original_index: 289}
+    - {activation_epoch: 265, exit_epoch: 956, original_index: 290}
+    - {activation_epoch: 1058, exit_epoch: 18446744073709551615, original_index: 291}
+    - {activation_epoch: 1021, exit_epoch: 3626, original_index: 292}
+    - {activation_epoch: 948, exit_epoch: 3707, original_index: 293}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 294}
+    - {activation_epoch: 401, exit_epoch: 993, original_index: 295}
+    - {activation_epoch: 147, exit_epoch: 1034, original_index: 296}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 297}
+    - {activation_epoch: 1039, exit_epoch: 18446744073709551615, original_index: 298}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 299}
+    - {activation_epoch: 880, exit_epoch: 1077, original_index: 300}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 301}
+    - {activation_epoch: 999, exit_epoch: 2692, original_index: 302}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 303}
+    - {activation_epoch: 170, exit_epoch: 962, original_index: 304}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 305}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 306}
+    - {activation_epoch: 287, exit_epoch: 968, original_index: 307}
+    - {activation_epoch: 1014, exit_epoch: 4297, original_index: 308}
+    - {activation_epoch: 998, exit_epoch: 1377, original_index: 309}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 310}
+    - {activation_epoch: 973, exit_epoch: 18446744073709551615, original_index: 311}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 312}
+    - {activation_epoch: 596, exit_epoch: 970, original_index: 313}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 314}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 315}
+    - {activation_epoch: 252, exit_epoch: 985, original_index: 316}
+    - {activation_epoch: 326, exit_epoch: 946, original_index: 317}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 318}
+    - {activation_epoch: 1030, exit_epoch: 4663, original_index: 319}
+    - {activation_epoch: 185, exit_epoch: 961, original_index: 320}
+    - {activation_epoch: 974, exit_epoch: 18446744073709551615, original_index: 321}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 322}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 323}
+    - {activation_epoch: 970, exit_epoch: 1035, original_index: 324}
+    - {activation_epoch: 1019, exit_epoch: 3734, original_index: 325}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 326}
+    - {activation_epoch: 1004, exit_epoch: 4302, original_index: 327}
+    - {activation_epoch: 1015, exit_epoch: 18446744073709551615, original_index: 328}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 329}
+    - {activation_epoch: 457, exit_epoch: 984, original_index: 330}
+    - {activation_epoch: 361, exit_epoch: 989, original_index: 331}
+    - {activation_epoch: 987, exit_epoch: 1820, original_index: 332}
+    - {activation_epoch: 881, exit_epoch: 902, original_index: 333}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 334}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 335}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 336}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 337}
+    - {activation_epoch: 674, exit_epoch: 1083, original_index: 338}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 339}
+    - {activation_epoch: 981, exit_epoch: 18446744073709551615, original_index: 340}
+    - {activation_epoch: 1010, exit_epoch: 3936, original_index: 341}
+    - {activation_epoch: 693, exit_epoch: 979, original_index: 342}
+    - {activation_epoch: 1008, exit_epoch: 2126, original_index: 343}
+    - {activation_epoch: 969, exit_epoch: 983, original_index: 344}
+    - {activation_epoch: 573, exit_epoch: 994, original_index: 345}
+    - {activation_epoch: 1030, exit_epoch: 18446744073709551615, original_index: 346}
+    - {activation_epoch: 965, exit_epoch: 3474, original_index: 347}
+    - {activation_epoch: 469, exit_epoch: 1026, original_index: 348}
+    - {activation_epoch: 609, exit_epoch: 994, original_index: 349}
+    - {activation_epoch: 937, exit_epoch: 18446744073709551615, original_index: 350}
+    - {activation_epoch: 1063, exit_epoch: 2598, original_index: 351}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 352}
+    - {activation_epoch: 1006, exit_epoch: 18446744073709551615, original_index: 353}
+    - {activation_epoch: 1034, exit_epoch: 18446744073709551615, original_index: 354}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 355}
+    - {activation_epoch: 462, exit_epoch: 1019, original_index: 356}
+    - {activation_epoch: 804, exit_epoch: 984, original_index: 357}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 358}
+    - {activation_epoch: 974, exit_epoch: 3320, original_index: 359}
+    - {activation_epoch: 230, exit_epoch: 946, original_index: 360}
+    - {activation_epoch: 1032, exit_epoch: 2796, original_index: 361}
+    - {activation_epoch: 111, exit_epoch: 1043, original_index: 362}
+    - {activation_epoch: 915, exit_epoch: 1014, original_index: 363}
+    - {activation_epoch: 535, exit_epoch: 959, original_index: 364}
+    - {activation_epoch: 1030, exit_epoch: 18446744073709551615, original_index: 365}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 366}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 367}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 368}
+    - {activation_epoch: 1009, exit_epoch: 1115, original_index: 369}
+    - {activation_epoch: 988, exit_epoch: 18446744073709551615, original_index: 370}
+    - {activation_epoch: 205, exit_epoch: 986, original_index: 371}
+    - {activation_epoch: 1003, exit_epoch: 3537, original_index: 372}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 373}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 374}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 375}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 376}
+    - {activation_epoch: 1011, exit_epoch: 1648, original_index: 377}
+    - {activation_epoch: 123, exit_epoch: 1016, original_index: 378}
+    - {activation_epoch: 1003, exit_epoch: 3824, original_index: 379}
+    - {activation_epoch: 190, exit_epoch: 1026, original_index: 380}
+    - {activation_epoch: 835, exit_epoch: 1010, original_index: 381}
+    - {activation_epoch: 114, exit_epoch: 1002, original_index: 382}
+    - {activation_epoch: 847, exit_epoch: 1037, original_index: 383}
+    - {activation_epoch: 96, exit_epoch: 996, original_index: 384}
+    - {activation_epoch: 891, exit_epoch: 932, original_index: 385}
+    - {activation_epoch: 1039, exit_epoch: 18446744073709551615, original_index: 386}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 387}
+    - {activation_epoch: 988, exit_epoch: 18446744073709551615, original_index: 388}
+    - {activation_epoch: 994, exit_epoch: 2341, original_index: 389}
+    - {activation_epoch: 588, exit_epoch: 988, original_index: 390}
+    - {activation_epoch: 1015, exit_epoch: 4653, original_index: 391}
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 392}
+    - {activation_epoch: 987, exit_epoch: 1692, original_index: 393}
+    - {activation_epoch: 837, exit_epoch: 952, original_index: 394}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 395}
+    - {activation_epoch: 838, exit_epoch: 991, original_index: 396}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 397}
+    - {activation_epoch: 503, exit_epoch: 999, original_index: 398}
+    - {activation_epoch: 991, exit_epoch: 18446744073709551615, original_index: 399}
+    - {activation_epoch: 1009, exit_epoch: 2234, original_index: 400}
+    - {activation_epoch: 995, exit_epoch: 1782, original_index: 401}
+    - {activation_epoch: 336, exit_epoch: 973, original_index: 402}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 403}
+    - {activation_epoch: 246, exit_epoch: 1033, original_index: 404}
+    - {activation_epoch: 762, exit_epoch: 943, original_index: 405}
+    - {activation_epoch: 995, exit_epoch: 4618, original_index: 406}
+    - {activation_epoch: 388, exit_epoch: 1011, original_index: 407}
+    - {activation_epoch: 308, exit_epoch: 943, original_index: 408}
+    - {activation_epoch: 804, exit_epoch: 990, original_index: 409}
+    - {activation_epoch: 502, exit_epoch: 1057, original_index: 410}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 411}
+    - {activation_epoch: 675, exit_epoch: 976, original_index: 412}
+    - {activation_epoch: 788, exit_epoch: 1015, original_index: 413}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 414}
+    - {activation_epoch: 299, exit_epoch: 1052, original_index: 415}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 416}
+    - {activation_epoch: 994, exit_epoch: 3645, original_index: 417}
+    - {activation_epoch: 927, exit_epoch: 18446744073709551615, original_index: 418}
+    - {activation_epoch: 383, exit_epoch: 999, original_index: 419}
+    - {activation_epoch: 817, exit_epoch: 1002, original_index: 420}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 421}
+    - {activation_epoch: 1003, exit_epoch: 1843, original_index: 422}
+    - {activation_epoch: 999, exit_epoch: 4076, original_index: 423}
+    - {activation_epoch: 941, exit_epoch: 18446744073709551615, original_index: 424}
+    - {activation_epoch: 1039, exit_epoch: 1688, original_index: 425}
+    - {activation_epoch: 983, exit_epoch: 4068, original_index: 426}
+    - {activation_epoch: 61, exit_epoch: 1007, original_index: 427}
+    - {activation_epoch: 941, exit_epoch: 1002, original_index: 428}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 429}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 430}
+    - {activation_epoch: 99, exit_epoch: 1014, original_index: 431}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 432}
+    - {activation_epoch: 166, exit_epoch: 990, original_index: 433}
+    - {activation_epoch: 962, exit_epoch: 3229, original_index: 434}
+    - {activation_epoch: 861, exit_epoch: 1068, original_index: 435}
+    - {activation_epoch: 785, exit_epoch: 984, original_index: 436}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 437}
+    - {activation_epoch: 520, exit_epoch: 979, original_index: 438}
+    - {activation_epoch: 975, exit_epoch: 18446744073709551615, original_index: 439}
+    - {activation_epoch: 185, exit_epoch: 1032, original_index: 440}
+    - {activation_epoch: 164, exit_epoch: 1000, original_index: 441}
+    - {activation_epoch: 1001, exit_epoch: 2584, original_index: 442}
+    - {activation_epoch: 1012, exit_epoch: 4248, original_index: 443}
+    - {activation_epoch: 941, exit_epoch: 1804, original_index: 444}
+    - {activation_epoch: 851, exit_epoch: 1017, original_index: 445}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 446}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 447}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 448}
+    - {activation_epoch: 338, exit_epoch: 1031, original_index: 449}
+    - {activation_epoch: 959, exit_epoch: 1607, original_index: 450}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 451}
+    - {activation_epoch: 955, exit_epoch: 18446744073709551615, original_index: 452}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 453}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 454}
+    - {activation_epoch: 445, exit_epoch: 996, original_index: 455}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 456}
+    - {activation_epoch: 114, exit_epoch: 1002, original_index: 457}
+    - {activation_epoch: 1015, exit_epoch: 18446744073709551615, original_index: 458}
+    - {activation_epoch: 91, exit_epoch: 1006, original_index: 459}
+    - {activation_epoch: 991, exit_epoch: 3658, original_index: 460}
+    - {activation_epoch: 949, exit_epoch: 3066, original_index: 461}
+    - {activation_epoch: 956, exit_epoch: 1151, original_index: 462}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 463}
+    - {activation_epoch: 455, exit_epoch: 1013, original_index: 464}
+    - {activation_epoch: 447, exit_epoch: 981, original_index: 465}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 466}
+    - {activation_epoch: 1049, exit_epoch: 18446744073709551615, original_index: 467}
+    - {activation_epoch: 789, exit_epoch: 1048, original_index: 468}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 469}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 470}
+    - {activation_epoch: 1030, exit_epoch: 18446744073709551615, original_index: 471}
+    - {activation_epoch: 971, exit_epoch: 1428, original_index: 472}
+    - {activation_epoch: 801, exit_epoch: 1042, original_index: 473}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 474}
+    - {activation_epoch: 97, exit_epoch: 955, original_index: 475}
+    - {activation_epoch: 1030, exit_epoch: 2014, original_index: 476}
   output:
-  - - committee: [126, 405, 361]
-      shard: 233
-      total_validator_count: 199
-  - - committee: [263, 16, 342]
-      shard: 234
-      total_validator_count: 199
-  - - committee: [180, 347, 21]
-      shard: 235
-      total_validator_count: 199
-  - - committee: [443, 370, 354]
-      shard: 236
-      total_validator_count: 199
-  - - committee: [115, 138, 320]
-      shard: 237
-      total_validator_count: 199
-  - - committee: [268, 286, 322]
-      shard: 238
-      total_validator_count: 199
-  - - committee: [304, 75, 338]
-      shard: 239
-      total_validator_count: 199
-  - - committee: [2, 362, 215]
-      shard: 240
-      total_validator_count: 199
-  - - committee: [228, 94, 190]
-      shard: 241
-      total_validator_count: 199
-  - - committee: [105, 117, 462, 292]
-      shard: 242
-      total_validator_count: 199
-  - - committee: [333, 343, 20]
-      shard: 243
-      total_validator_count: 199
-  - - committee: [156, 234, 55]
-      shard: 244
-      total_validator_count: 199
-  - - committee: [35, 367, 363]
-      shard: 245
-      total_validator_count: 199
-  - - committee: [114, 261, 80]
-      shard: 246
-      total_validator_count: 199
-  - - committee: [337, 271, 274]
-      shard: 247
-      total_validator_count: 199
-  - - committee: [59, 54, 299]
-      shard: 248
-      total_validator_count: 199
-  - - committee: [457, 64, 301]
-      shard: 249
-      total_validator_count: 199
-  - - committee: [318, 419, 220]
-      shard: 250
-      total_validator_count: 199
-  - - committee: [424, 316, 19, 10]
-      shard: 251
-      total_validator_count: 199
-  - - committee: [191, 195, 213]
-      shard: 252
-      total_validator_count: 199
-  - - committee: [236, 91, 110]
-      shard: 253
-      total_validator_count: 199
-  - - committee: [34, 136, 90]
-      shard: 254
-      total_validator_count: 199
-  - - committee: [359, 73, 382]
-      shard: 255
-      total_validator_count: 199
-  - - committee: [65, 251, 193]
-      shard: 256
-      total_validator_count: 199
-  - - committee: [475, 194, 57]
-      shard: 257
-      total_validator_count: 199
-  - - committee: [92, 223, 15]
-      shard: 258
-      total_validator_count: 199
-  - - committee: [38, 69, 124]
-      shard: 259
-      total_validator_count: 199
-  - - committee: [244, 312, 466, 332]
-      shard: 260
-      total_validator_count: 199
-  - - committee: [434, 290, 162]
-      shard: 261
-      total_validator_count: 199
-  - - committee: [308, 324, 171]
-      shard: 262
-      total_validator_count: 199
-  - - committee: [233, 256, 470]
-      shard: 263
-      total_validator_count: 199
-  - - committee: [473, 227, 260]
-      shard: 264
-      total_validator_count: 199
-  - - committee: [247, 112, 229]
-      shard: 265
-      total_validator_count: 199
-  - - committee: [413, 340, 42]
-      shard: 266
-      total_validator_count: 199
-  - - committee: [230, 471, 315]
-      shard: 267
-      total_validator_count: 199
-  - - committee: [41, 321, 440]
-      shard: 268
-      total_validator_count: 199
-  - - committee: [306, 17, 140, 352]
-      shard: 269
-      total_validator_count: 199
-  - - committee: [153, 289, 68]
-      shard: 270
-      total_validator_count: 199
-  - - committee: [85, 402, 87]
-      shard: 271
-      total_validator_count: 199
-  - - committee: [449, 157, 221]
-      shard: 272
-      total_validator_count: 199
-  - - committee: [155, 104, 294]
-      shard: 273
-      total_validator_count: 199
-  - - committee: [200, 310, 454]
-      shard: 274
-      total_validator_count: 199
-  - - committee: [14, 442, 423]
-      shard: 275
-      total_validator_count: 199
-  - - committee: [60, 311, 238]
-      shard: 276
-      total_validator_count: 199
-  - - committee: [387, 100, 131]
-      shard: 277
-      total_validator_count: 199
-  - - committee: [178, 12, 181, 27]
-      shard: 278
-      total_validator_count: 199
-  - - committee: [436, 262, 13]
-      shard: 279
-      total_validator_count: 199
-  - - committee: [235, 47, 376]
-      shard: 280
-      total_validator_count: 199
-  - - committee: [120, 79, 224]
-      shard: 281
-      total_validator_count: 199
-  - - committee: [344, 476, 464]
-      shard: 282
-      total_validator_count: 199
-  - - committee: [84, 295, 151]
-      shard: 283
-      total_validator_count: 199
-  - - committee: [7, 204, 386]
-      shard: 284
-      total_validator_count: 199
-  - - committee: [129, 163, 243]
-      shard: 285
-      total_validator_count: 199
-  - - committee: [88, 216, 445]
-      shard: 286
-      total_validator_count: 199
-  - - committee: [212, 353, 5, 52]
-      shard: 287
-      total_validator_count: 199
-  - - committee: [479, 277, 469]
-      shard: 288
-      total_validator_count: 199
-  - - committee: [391, 169, 130]
-      shard: 289
-      total_validator_count: 199
-  - - committee: [164, 328, 149]
-      shard: 290
-      total_validator_count: 199
-  - - committee: [208, 282, 259]
-      shard: 291
-      total_validator_count: 199
-  - - committee: [339, 293, 58]
-      shard: 292
-      total_validator_count: 199
-  - - committee: [459, 385, 89]
-      shard: 293
-      total_validator_count: 199
-  - - committee: [135, 25, 211]
-      shard: 294
-      total_validator_count: 199
-  - - committee: [159, 317, 240]
-      shard: 295
-      total_validator_count: 199
-  - - committee: [205, 86, 326, 202]
-      shard: 296
-      total_validator_count: 199
-  seed: '0xeefb66740fd23df786731edb105354862abc8bc52ee4d0bffe8b7bc2d61f22d7'
+  - [462, 274]
+  - [217, 168, 347]
+  - [166, 85, 404]
+  - [223, 83, 284]
+  - [202, 255, 52]
+  - [224, 457]
+  - [469, 435, 473]
+  - [452, 279, 21]
+  - [450, 406, 197]
+  - [190, 278, 40]
+  - [253, 424, 126]
+  - [58, 461]
+  - [282, 431, 47]
+  - [348, 221, 399]
+  - [25, 86, 245]
+  - [231, 62, 192]
+  - [194, 200, 378]
+  - [370, 423]
+  - [103, 380, 460]
+  - [171, 283, 45]
+  - [148, 121, 66]
+  - [28, 440, 39]
+  - [177, 182, 31]
+  - [266, 132]
+  - [19, 133, 321]
+  - [164, 15, 410]
+  - [170, 243, 180]
+  - [264, 65, 18]
+  - [472, 99, 413]
+  - [420, 324]
+  - [76, 51, 388]
+  - [145, 418, 257]
+  - [238, 256, 359]
+  - [383, 213, 332]
+  - [449, 22]
+  - [254, 296, 60]
+  - [2, 29, 444]
+  - [338, 199, 124]
+  - [271, 129, 302]
+  - [288, 293, 428]
+  - [155, 247]
+  - [464, 300, 67]
+  - [35, 363, 426]
+  - [453, 272, 429]
+  - [153, 203, 9]
+  - [401, 382, 37]
+  - [445, 407]
+  - [281, 82, 140]
+  - [362, 90, 49]
+  - [434, 309, 311]
+  - [122, 4, 350]
+  - [14, 204, 269]
+  - [141, 123]
+  - [212, 120, 87]
+  - [7, 111, 356]
+  - [193, 64, 459]
+  - [415, 276, 8]
+  - [73, 381, 16]
+  - [340, 417]
+  - [439, 252, 468]
+  - [393, 427, 389]
+  - [216, 20, 198]
+  - [242, 161, 81]
+  - [119, 211, 96]
+  seed: '0xcad09d3965d0ed9bcad1a128900c6626bcf05c5eeddb4ed80a0c6d2e75b6b6a6'
 - input:
-    crosslinking_start_shard: 400
-    validators_status: [0, 4, 0, 3, 1, 2, 1, 2, 2, 2, 1, 0, 3, 0, 2, 4, 4, 4, 2, 2,
-      2, 1, 1, 4, 1, 2, 1, 3, 0, 0, 3, 4, 1, 1, 0, 4, 3, 0, 4, 4, 3, 2, 3, 1, 3, 1,
-      1, 3, 0, 0, 0, 4, 1, 1, 1, 1, 2, 3, 3, 4, 2, 0, 2, 3, 3, 0, 3, 0, 2, 4, 3, 3,
-      3, 2, 1, 3, 4, 2, 3, 0, 2, 0, 1, 3, 1, 4, 4, 1, 4, 4, 2, 1, 3, 3, 2, 3, 3, 4,
-      4, 4, 2, 3, 0, 0, 2, 3, 1, 4, 2, 3, 2, 2, 4, 0, 0, 4, 0, 1, 0, 3, 0, 2, 2, 1,
-      3, 3, 2, 3, 4, 3, 1, 2, 0, 0, 1, 4, 3, 1, 2, 0, 4, 1, 1, 0, 0, 4, 1, 2, 4, 3,
-      3, 3, 2, 0, 4, 4, 0, 1, 2, 0, 2, 0, 3, 1, 2, 0, 1, 0, 4, 0, 3, 3, 0, 3, 0, 0,
-      3, 3, 4, 4, 2, 3, 2, 0, 2, 0, 4, 4, 4, 2, 2, 3, 4, 3, 2, 2, 4, 3, 4, 0, 4, 4,
-      3, 1, 0, 2, 3, 1, 1, 2, 3, 0, 0, 4, 3, 2, 2, 3, 1, 0, 3, 1, 0, 1, 1, 2, 2, 2,
-      4, 0, 2, 4, 4, 4, 4, 2, 4, 4, 0, 4, 1, 4, 4, 4, 3, 1, 2, 3, 4, 1, 1, 1, 0, 3,
-      0, 2, 4, 1, 1, 3, 3, 0, 4, 1, 1, 3, 2, 0, 2, 2, 0, 0, 4, 2, 4, 1, 1, 0, 4, 2,
-      3, 1, 0, 3, 2, 2, 1, 0, 3, 2, 4, 0, 3, 2, 3, 1, 1, 1, 2, 2, 0, 3, 2, 3, 3, 0,
-      2, 1, 4, 4, 2, 1, 3, 0, 2, 1, 0, 2, 3, 2, 2, 3, 0, 4, 0, 3, 2, 3, 1, 4, 2, 1,
-      0, 4, 2, 1, 1, 0, 0, 0, 4, 4, 0, 1, 1, 0, 1, 1, 4, 0, 4, 1, 0, 0, 0, 3, 2, 0,
-      3, 3, 2, 3, 0, 3, 1, 1, 3, 0, 4, 4, 3, 4, 2, 2, 3, 3, 0, 0, 3, 1, 2, 0, 2, 2,
-      1, 1, 1, 4, 4, 3, 0, 3, 3, 3, 2, 1, 1, 2, 1, 1, 3, 4, 1, 0, 4, 0, 4, 4, 0, 3]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 958, exit_epoch: 18446744073709551615, original_index: 0}
+    - {activation_epoch: 996, exit_epoch: 3852, original_index: 1}
+    - {activation_epoch: 928, exit_epoch: 1045, original_index: 2}
+    - {activation_epoch: 186, exit_epoch: 1042, original_index: 3}
+    - {activation_epoch: 599, exit_epoch: 954, original_index: 4}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 5}
+    - {activation_epoch: 1022, exit_epoch: 1142, original_index: 6}
+    - {activation_epoch: 999, exit_epoch: 2407, original_index: 7}
+    - {activation_epoch: 966, exit_epoch: 3575, original_index: 8}
+    - {activation_epoch: 608, exit_epoch: 1032, original_index: 9}
+    - {activation_epoch: 670, exit_epoch: 1018, original_index: 10}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 11}
+    - {activation_epoch: 387, exit_epoch: 1044, original_index: 12}
+    - {activation_epoch: 260, exit_epoch: 991, original_index: 13}
+    - {activation_epoch: 537, exit_epoch: 1069, original_index: 14}
+    - {activation_epoch: 813, exit_epoch: 1027, original_index: 15}
+    - {activation_epoch: 959, exit_epoch: 18446744073709551615, original_index: 16}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 17}
+    - {activation_epoch: 441, exit_epoch: 974, original_index: 18}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 19}
+    - {activation_epoch: 981, exit_epoch: 18446744073709551615, original_index: 20}
+    - {activation_epoch: 856, exit_epoch: 990, original_index: 21}
+    - {activation_epoch: 780, exit_epoch: 1021, original_index: 22}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 23}
+    - {activation_epoch: 934, exit_epoch: 18446744073709551615, original_index: 24}
+    - {activation_epoch: 1003, exit_epoch: 1413, original_index: 25}
+    - {activation_epoch: 1000, exit_epoch: 4572, original_index: 26}
+    - {activation_epoch: 176, exit_epoch: 1012, original_index: 27}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 28}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 29}
+    - {activation_epoch: 1071, exit_epoch: 4508, original_index: 30}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 31}
+    - {activation_epoch: 152, exit_epoch: 1004, original_index: 32}
+    - {activation_epoch: 1006, exit_epoch: 18446744073709551615, original_index: 33}
+    - {activation_epoch: 1010, exit_epoch: 1583, original_index: 34}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 35}
+    - {activation_epoch: 522, exit_epoch: 1058, original_index: 36}
+    - {activation_epoch: 167, exit_epoch: 987, original_index: 37}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 953, exit_epoch: 18446744073709551615, original_index: 39}
+    - {activation_epoch: 974, exit_epoch: 1036, original_index: 40}
+    - {activation_epoch: 1006, exit_epoch: 2405, original_index: 41}
+    - {activation_epoch: 522, exit_epoch: 1043, original_index: 42}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 43}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 44}
+    - {activation_epoch: 1033, exit_epoch: 2512, original_index: 45}
+    - {activation_epoch: 158, exit_epoch: 970, original_index: 46}
+    - {activation_epoch: 957, exit_epoch: 18446744073709551615, original_index: 47}
+    - {activation_epoch: 979, exit_epoch: 18446744073709551615, original_index: 48}
+    - {activation_epoch: 31, exit_epoch: 999, original_index: 49}
+    - {activation_epoch: 193, exit_epoch: 986, original_index: 50}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 51}
+    - {activation_epoch: 745, exit_epoch: 976, original_index: 52}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 53}
+    - {activation_epoch: 498, exit_epoch: 1000, original_index: 54}
+    - {activation_epoch: 1067, exit_epoch: 2833, original_index: 55}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 56}
+    - {activation_epoch: 675, exit_epoch: 1034, original_index: 57}
+    - {activation_epoch: 1009, exit_epoch: 2261, original_index: 58}
+    - {activation_epoch: 943, exit_epoch: 18446744073709551615, original_index: 59}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 60}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 61}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 62}
+    - {activation_epoch: 1035, exit_epoch: 4091, original_index: 63}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 64}
+    - {activation_epoch: 957, exit_epoch: 18446744073709551615, original_index: 65}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 66}
+    - {activation_epoch: 495, exit_epoch: 991, original_index: 67}
+    - {activation_epoch: 1021, exit_epoch: 2953, original_index: 68}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 69}
+    - {activation_epoch: 43, exit_epoch: 991, original_index: 70}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 71}
+    - {activation_epoch: 810, exit_epoch: 1025, original_index: 72}
+    - {activation_epoch: 456, exit_epoch: 1035, original_index: 73}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 74}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 75}
+    - {activation_epoch: 600, exit_epoch: 948, original_index: 76}
+    - {activation_epoch: 926, exit_epoch: 4071, original_index: 77}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 78}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 79}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 80}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 971, exit_epoch: 18446744073709551615, original_index: 82}
+    - {activation_epoch: 259, exit_epoch: 1010, original_index: 83}
+    - {activation_epoch: 709, exit_epoch: 1018, original_index: 84}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 85}
+    - {activation_epoch: 799, exit_epoch: 975, original_index: 86}
+    - {activation_epoch: 1063, exit_epoch: 18446744073709551615, original_index: 87}
+    - {activation_epoch: 979, exit_epoch: 18446744073709551615, original_index: 88}
+    - {activation_epoch: 1062, exit_epoch: 18446744073709551615, original_index: 89}
+    - {activation_epoch: 1052, exit_epoch: 18446744073709551615, original_index: 90}
+    - {activation_epoch: 1009, exit_epoch: 2011, original_index: 91}
+    - {activation_epoch: 526, exit_epoch: 1002, original_index: 92}
+    - {activation_epoch: 342, exit_epoch: 989, original_index: 93}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 94}
+    - {activation_epoch: 964, exit_epoch: 18446744073709551615, original_index: 95}
+    - {activation_epoch: 973, exit_epoch: 18446744073709551615, original_index: 96}
+    - {activation_epoch: 72, exit_epoch: 1006, original_index: 97}
+    - {activation_epoch: 117, exit_epoch: 1033, original_index: 98}
+    - {activation_epoch: 1046, exit_epoch: 3436, original_index: 99}
+    - {activation_epoch: 1052, exit_epoch: 3787, original_index: 100}
+    - {activation_epoch: 535, exit_epoch: 1022, original_index: 101}
+    - {activation_epoch: 988, exit_epoch: 2581, original_index: 102}
+    - {activation_epoch: 1070, exit_epoch: 2213, original_index: 103}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 104}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 105}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 106}
+    - {activation_epoch: 999, exit_epoch: 2738, original_index: 107}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 108}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 109}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 110}
+    - {activation_epoch: 975, exit_epoch: 2515, original_index: 111}
+    - {activation_epoch: 1017, exit_epoch: 3931, original_index: 112}
+    - {activation_epoch: 805, exit_epoch: 1046, original_index: 113}
+    - {activation_epoch: 942, exit_epoch: 1021, original_index: 114}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 115}
+    - {activation_epoch: 815, exit_epoch: 966, original_index: 116}
+    - {activation_epoch: 425, exit_epoch: 1051, original_index: 117}
+    - {activation_epoch: 76, exit_epoch: 1002, original_index: 118}
+    - {activation_epoch: 441, exit_epoch: 970, original_index: 119}
+    - {activation_epoch: 76, exit_epoch: 1039, original_index: 120}
+    - {activation_epoch: 910, exit_epoch: 2652, original_index: 121}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 122}
+    - {activation_epoch: 953, exit_epoch: 1065, original_index: 123}
+    - {activation_epoch: 872, exit_epoch: 961, original_index: 124}
+    - {activation_epoch: 393, exit_epoch: 996, original_index: 125}
+    - {activation_epoch: 1044, exit_epoch: 18446744073709551615, original_index: 126}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 127}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 128}
+    - {activation_epoch: 775, exit_epoch: 997, original_index: 129}
+    - {activation_epoch: 1036, exit_epoch: 4986, original_index: 130}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 131}
+    - {activation_epoch: 975, exit_epoch: 4603, original_index: 132}
+    - {activation_epoch: 1082, exit_epoch: 4239, original_index: 133}
+    - {activation_epoch: 271, exit_epoch: 1066, original_index: 134}
+    - {activation_epoch: 352, exit_epoch: 1027, original_index: 135}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 136}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 137}
+    - {activation_epoch: 955, exit_epoch: 2832, original_index: 138}
+    - {activation_epoch: 976, exit_epoch: 18446744073709551615, original_index: 139}
+    - {activation_epoch: 939, exit_epoch: 18446744073709551615, original_index: 140}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 141}
+    - {activation_epoch: 1050, exit_epoch: 18446744073709551615, original_index: 142}
+    - {activation_epoch: 987, exit_epoch: 2069, original_index: 143}
+    - {activation_epoch: 1042, exit_epoch: 3482, original_index: 144}
+    - {activation_epoch: 728, exit_epoch: 1034, original_index: 145}
+    - {activation_epoch: 1059, exit_epoch: 3760, original_index: 146}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 147}
+    - {activation_epoch: 839, exit_epoch: 1010, original_index: 148}
+    - {activation_epoch: 172, exit_epoch: 1021, original_index: 149}
+    - {activation_epoch: 1016, exit_epoch: 1541, original_index: 150}
+    - {activation_epoch: 533, exit_epoch: 1036, original_index: 151}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 152}
+    - {activation_epoch: 791, exit_epoch: 1051, original_index: 153}
+    - {activation_epoch: 936, exit_epoch: 1010, original_index: 154}
+    - {activation_epoch: 306, exit_epoch: 955, original_index: 155}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 156}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 157}
+    - {activation_epoch: 48, exit_epoch: 1039, original_index: 158}
+    - {activation_epoch: 1004, exit_epoch: 1524, original_index: 159}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 160}
+    - {activation_epoch: 935, exit_epoch: 4716, original_index: 161}
+    - {activation_epoch: 137, exit_epoch: 1028, original_index: 162}
+    - {activation_epoch: 616, exit_epoch: 972, original_index: 163}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 164}
+    - {activation_epoch: 115, exit_epoch: 1044, original_index: 165}
+    - {activation_epoch: 31, exit_epoch: 1017, original_index: 166}
+    - {activation_epoch: 990, exit_epoch: 3057, original_index: 167}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 168}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 169}
+    - {activation_epoch: 537, exit_epoch: 1022, original_index: 170}
+    - {activation_epoch: 996, exit_epoch: 18446744073709551615, original_index: 171}
+    - {activation_epoch: 582, exit_epoch: 987, original_index: 172}
+    - {activation_epoch: 1026, exit_epoch: 1072, original_index: 173}
+    - {activation_epoch: 969, exit_epoch: 4276, original_index: 174}
+    - {activation_epoch: 983, exit_epoch: 2106, original_index: 175}
+    - {activation_epoch: 975, exit_epoch: 3514, original_index: 176}
+    - {activation_epoch: 53, exit_epoch: 965, original_index: 177}
+    - {activation_epoch: 652, exit_epoch: 1069, original_index: 178}
+    - {activation_epoch: 950, exit_epoch: 18446744073709551615, original_index: 179}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 180}
+    - {activation_epoch: 66, exit_epoch: 1036, original_index: 181}
+    - {activation_epoch: 447, exit_epoch: 998, original_index: 182}
+    - {activation_epoch: 958, exit_epoch: 18446744073709551615, original_index: 183}
+    - {activation_epoch: 910, exit_epoch: 971, original_index: 184}
+    - {activation_epoch: 961, exit_epoch: 1005, original_index: 185}
+    - {activation_epoch: 1042, exit_epoch: 18446744073709551615, original_index: 186}
+    - {activation_epoch: 771, exit_epoch: 930, original_index: 187}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 188}
+    - {activation_epoch: 771, exit_epoch: 981, original_index: 189}
+    - {activation_epoch: 997, exit_epoch: 18446744073709551615, original_index: 190}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 191}
+    - {activation_epoch: 951, exit_epoch: 1006, original_index: 192}
+    - {activation_epoch: 974, exit_epoch: 18446744073709551615, original_index: 193}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 194}
+    - {activation_epoch: 1004, exit_epoch: 2742, original_index: 195}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 196}
+    - {activation_epoch: 864, exit_epoch: 950, original_index: 197}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 198}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 199}
+    - {activation_epoch: 996, exit_epoch: 1404, original_index: 200}
+    - {activation_epoch: 799, exit_epoch: 986, original_index: 201}
+    - {activation_epoch: 342, exit_epoch: 962, original_index: 202}
+    - {activation_epoch: 875, exit_epoch: 1030, original_index: 203}
+    - {activation_epoch: 678, exit_epoch: 1059, original_index: 204}
+    - {activation_epoch: 1049, exit_epoch: 18446744073709551615, original_index: 205}
+    - {activation_epoch: 509, exit_epoch: 977, original_index: 206}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 207}
+    - {activation_epoch: 676, exit_epoch: 935, original_index: 208}
+    - {activation_epoch: 618, exit_epoch: 1029, original_index: 209}
+    - {activation_epoch: 725, exit_epoch: 999, original_index: 210}
+    - {activation_epoch: 223, exit_epoch: 1029, original_index: 211}
+    - {activation_epoch: 999, exit_epoch: 3707, original_index: 212}
+    - {activation_epoch: 894, exit_epoch: 995, original_index: 213}
+    - {activation_epoch: 414, exit_epoch: 1075, original_index: 214}
+    - {activation_epoch: 353, exit_epoch: 933, original_index: 215}
+    - {activation_epoch: 305, exit_epoch: 995, original_index: 216}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 217}
+    - {activation_epoch: 1017, exit_epoch: 18446744073709551615, original_index: 218}
+    - {activation_epoch: 707, exit_epoch: 1020, original_index: 219}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 220}
+    - {activation_epoch: 346, exit_epoch: 939, original_index: 221}
+    - {activation_epoch: 260, exit_epoch: 980, original_index: 222}
+    - {activation_epoch: 190, exit_epoch: 948, original_index: 223}
+    - {activation_epoch: 258, exit_epoch: 1004, original_index: 224}
+    - {activation_epoch: 676, exit_epoch: 1014, original_index: 225}
+    - {activation_epoch: 998, exit_epoch: 3539, original_index: 226}
+    - {activation_epoch: 960, exit_epoch: 18446744073709551615, original_index: 227}
+    - {activation_epoch: 976, exit_epoch: 2357, original_index: 228}
+    - {activation_epoch: 982, exit_epoch: 4310, original_index: 229}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 230}
+    - {activation_epoch: 964, exit_epoch: 18446744073709551615, original_index: 231}
+    - {activation_epoch: 558, exit_epoch: 1025, original_index: 232}
+    - {activation_epoch: 805, exit_epoch: 1027, original_index: 233}
+    - {activation_epoch: 442, exit_epoch: 963, original_index: 234}
+    - {activation_epoch: 942, exit_epoch: 18446744073709551615, original_index: 235}
+    - {activation_epoch: 1045, exit_epoch: 18446744073709551615, original_index: 236}
+    - {activation_epoch: 1058, exit_epoch: 3421, original_index: 237}
+    - {activation_epoch: 937, exit_epoch: 956, original_index: 238}
+    - {activation_epoch: 279, exit_epoch: 932, original_index: 239}
+    - {activation_epoch: 302, exit_epoch: 982, original_index: 240}
+    - {activation_epoch: 846, exit_epoch: 969, original_index: 241}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 242}
+    - {activation_epoch: 117, exit_epoch: 1003, original_index: 243}
+    - {activation_epoch: 464, exit_epoch: 972, original_index: 244}
+    - {activation_epoch: 649, exit_epoch: 1070, original_index: 245}
+    - {activation_epoch: 157, exit_epoch: 1015, original_index: 246}
+    - {activation_epoch: 1017, exit_epoch: 1805, original_index: 247}
+    - {activation_epoch: 1033, exit_epoch: 3652, original_index: 248}
+    - {activation_epoch: 1037, exit_epoch: 2173, original_index: 249}
+    - {activation_epoch: 1012, exit_epoch: 2154, original_index: 250}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 251}
+    - {activation_epoch: 1004, exit_epoch: 4877, original_index: 252}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 253}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 254}
+    - {activation_epoch: 317, exit_epoch: 1030, original_index: 255}
+    - {activation_epoch: 1066, exit_epoch: 3609, original_index: 256}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 257}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 258}
+    - {activation_epoch: 65, exit_epoch: 1007, original_index: 259}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 260}
+    - {activation_epoch: 958, exit_epoch: 18446744073709551615, original_index: 261}
+    - {activation_epoch: 568, exit_epoch: 1040, original_index: 262}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 263}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 264}
+    - {activation_epoch: 1040, exit_epoch: 3733, original_index: 265}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 266}
+    - {activation_epoch: 696, exit_epoch: 998, original_index: 267}
+    - {activation_epoch: 61, exit_epoch: 1074, original_index: 268}
+    - {activation_epoch: 659, exit_epoch: 997, original_index: 269}
+    - {activation_epoch: 867, exit_epoch: 967, original_index: 270}
+    - {activation_epoch: 1051, exit_epoch: 2686, original_index: 271}
+    - {activation_epoch: 1040, exit_epoch: 4691, original_index: 272}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 273}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 274}
+    - {activation_epoch: 647, exit_epoch: 962, original_index: 275}
+    - {activation_epoch: 12, exit_epoch: 974, original_index: 276}
+    - {activation_epoch: 976, exit_epoch: 2000, original_index: 277}
+    - {activation_epoch: 1005, exit_epoch: 3284, original_index: 278}
+    - {activation_epoch: 952, exit_epoch: 966, original_index: 279}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 280}
+    - {activation_epoch: 62, exit_epoch: 910, original_index: 281}
+    - {activation_epoch: 335, exit_epoch: 982, original_index: 282}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 283}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 284}
+    - {activation_epoch: 537, exit_epoch: 1008, original_index: 285}
+    - {activation_epoch: 539, exit_epoch: 1001, original_index: 286}
+    - {activation_epoch: 429, exit_epoch: 1005, original_index: 287}
+    - {activation_epoch: 547, exit_epoch: 952, original_index: 288}
+    - {activation_epoch: 1035, exit_epoch: 18446744073709551615, original_index: 289}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 290}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 291}
+    - {activation_epoch: 986, exit_epoch: 2282, original_index: 292}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 293}
+    - {activation_epoch: 943, exit_epoch: 1032, original_index: 294}
+    - {activation_epoch: 990, exit_epoch: 4080, original_index: 295}
+    - {activation_epoch: 498, exit_epoch: 1004, original_index: 296}
+    - {activation_epoch: 1039, exit_epoch: 18446744073709551615, original_index: 297}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 298}
+    - {activation_epoch: 523, exit_epoch: 967, original_index: 299}
+    - {activation_epoch: 1021, exit_epoch: 4880, original_index: 300}
+    - {activation_epoch: 291, exit_epoch: 971, original_index: 301}
+    - {activation_epoch: 996, exit_epoch: 18446744073709551615, original_index: 302}
+    - {activation_epoch: 693, exit_epoch: 1012, original_index: 303}
+    - {activation_epoch: 979, exit_epoch: 18446744073709551615, original_index: 304}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 305}
+    - {activation_epoch: 710, exit_epoch: 980, original_index: 306}
+    - {activation_epoch: 948, exit_epoch: 18446744073709551615, original_index: 307}
+    - {activation_epoch: 1022, exit_epoch: 18446744073709551615, original_index: 308}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 309}
+    - {activation_epoch: 482, exit_epoch: 979, original_index: 310}
+    - {activation_epoch: 997, exit_epoch: 18446744073709551615, original_index: 311}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 312}
+    - {activation_epoch: 41, exit_epoch: 960, original_index: 313}
+    - {activation_epoch: 560, exit_epoch: 1045, original_index: 314}
+    - {activation_epoch: 549, exit_epoch: 990, original_index: 315}
+    - {activation_epoch: 941, exit_epoch: 1014, original_index: 316}
+    - {activation_epoch: 338, exit_epoch: 959, original_index: 317}
+    - {activation_epoch: 956, exit_epoch: 18446744073709551615, original_index: 318}
+    - {activation_epoch: 509, exit_epoch: 1037, original_index: 319}
+    - {activation_epoch: 872, exit_epoch: 1067, original_index: 320}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 321}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 322}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 323}
+    - {activation_epoch: 598, exit_epoch: 1037, original_index: 324}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 325}
+    - {activation_epoch: 462, exit_epoch: 976, original_index: 326}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 327}
+    - {activation_epoch: 946, exit_epoch: 18446744073709551615, original_index: 328}
+    - {activation_epoch: 67, exit_epoch: 1000, original_index: 329}
+    - {activation_epoch: 964, exit_epoch: 18446744073709551615, original_index: 330}
+    - {activation_epoch: 67, exit_epoch: 961, original_index: 331}
+    - {activation_epoch: 929, exit_epoch: 979, original_index: 332}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 333}
+    - {activation_epoch: 1010, exit_epoch: 1027, original_index: 334}
+    - {activation_epoch: 1070, exit_epoch: 1829, original_index: 335}
+    - {activation_epoch: 33, exit_epoch: 969, original_index: 336}
+    - {activation_epoch: 947, exit_epoch: 2420, original_index: 337}
+    - {activation_epoch: 1063, exit_epoch: 3153, original_index: 338}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 339}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 340}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 341}
+    - {activation_epoch: 962, exit_epoch: 2308, original_index: 342}
+    - {activation_epoch: 981, exit_epoch: 3352, original_index: 343}
+    - {activation_epoch: 328, exit_epoch: 951, original_index: 344}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 345}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 346}
+    - {activation_epoch: 940, exit_epoch: 3682, original_index: 347}
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 348}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 349}
+    - {activation_epoch: 33, exit_epoch: 1030, original_index: 350}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 351}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 352}
+    - {activation_epoch: 982, exit_epoch: 3412, original_index: 353}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 354}
+    - {activation_epoch: 1039, exit_epoch: 18446744073709551615, original_index: 355}
+    - {activation_epoch: 895, exit_epoch: 979, original_index: 356}
+    - {activation_epoch: 995, exit_epoch: 18446744073709551615, original_index: 357}
+    - {activation_epoch: 482, exit_epoch: 983, original_index: 358}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 359}
+    - {activation_epoch: 600, exit_epoch: 928, original_index: 360}
+    - {activation_epoch: 856, exit_epoch: 951, original_index: 361}
   output:
-  - - committee: [80, 273]
-      shard: 400
-      total_validator_count: 161
-  - - committee: [163, 9, 141]
-      shard: 401
-      total_validator_count: 161
-  - - committee: [286, 195]
-      shard: 402
-      total_validator_count: 161
-  - - committee: [343, 314, 224]
-      shard: 403
-      total_validator_count: 161
-  - - committee: [275, 157]
-      shard: 404
-      total_validator_count: 161
-  - - committee: [43, 402, 134]
-      shard: 405
-      total_validator_count: 161
-  - - committee: [306, 289]
-      shard: 406
-      total_validator_count: 161
-  - - committee: [184, 180, 207]
-      shard: 407
-      total_validator_count: 161
-  - - committee: [281, 302]
-      shard: 408
-      total_validator_count: 161
-  - - committee: [384, 14, 91]
-      shard: 409
-      total_validator_count: 161
-  - - committee: [100, 347]
-      shard: 410
-      total_validator_count: 161
-  - - committee: [285, 264, 382]
-      shard: 411
-      total_validator_count: 161
-  - - committee: [126, 189]
-      shard: 412
-      total_validator_count: 161
-  - - committee: [351, 335, 18]
-      shard: 413
-      total_validator_count: 161
-  - - committee: [22, 336]
-      shard: 414
-      total_validator_count: 161
-  - - committee: [230, 257, 138]
-      shard: 415
-      total_validator_count: 161
-  - - committee: [235, 190]
-      shard: 416
-      total_validator_count: 161
-  - - committee: [251, 8, 208]
-      shard: 417
-      total_validator_count: 161
-  - - committee: [158, 331]
-      shard: 418
-      total_validator_count: 161
-  - - committee: [166, 326, 250]
-      shard: 419
-      total_validator_count: 161
-  - - committee: [60, 317]
-      shard: 420
-      total_validator_count: 161
-  - - committee: [221, 218, 55]
-      shard: 421
-      total_validator_count: 161
-  - - committee: [246, 137]
-      shard: 422
-      total_validator_count: 161
-  - - committee: [334, 223, 194]
-      shard: 423
-      total_validator_count: 161
-  - - committee: [396, 395]
-      shard: 424
-      total_validator_count: 161
-  - - committee: [182, 24, 130]
-      shard: 425
-      total_validator_count: 161
-  - - committee: [68, 356]
-      shard: 426
-      total_validator_count: 161
-  - - committee: [147, 296, 215]
-      shard: 427
-      total_validator_count: 161
-  - - committee: [82, 269]
-      shard: 428
-      total_validator_count: 161
-  - - committee: [106, 121, 41]
-      shard: 429
-      total_validator_count: 161
-  - - committee: [245, 226]
-      shard: 430
-      total_validator_count: 161
-  - - committee: [4, 268, 298]
-      shard: 431
-      total_validator_count: 161
-  - - committee: [21, 310, 108]
-      shard: 432
-      total_validator_count: 161
-  - - committee: [225, 319]
-      shard: 433
-      total_validator_count: 161
-  - - committee: [10, 276, 394]
-      shard: 434
-      total_validator_count: 161
-  - - committee: [90, 19]
-      shard: 435
-      total_validator_count: 161
-  - - committee: [56, 131, 73]
-      shard: 436
-      total_validator_count: 161
-  - - committee: [365, 25]
-      shard: 437
-      total_validator_count: 161
-  - - committee: [311, 344, 152]
-      shard: 438
-      total_validator_count: 161
-  - - committee: [94, 299]
-      shard: 439
-      total_validator_count: 161
-  - - committee: [111, 209, 360]
-      shard: 440
-      total_validator_count: 161
-  - - committee: [216, 263]
-      shard: 441
-      total_validator_count: 161
-  - - committee: [399, 397, 307]
-      shard: 442
-      total_validator_count: 161
-  - - committee: [5, 240]
-      shard: 443
-      total_validator_count: 161
-  - - committee: [284, 77, 372]
-      shard: 444
-      total_validator_count: 161
-  - - committee: [20, 142]
-      shard: 445
-      total_validator_count: 161
-  - - committee: [346, 386, 33]
-      shard: 446
-      total_validator_count: 161
-  - - committee: [6, 320]
-      shard: 447
-      total_validator_count: 161
-  - - committee: [385, 52, 249]
-      shard: 448
-      total_validator_count: 161
-  - - committee: [328, 203]
-      shard: 449
-      total_validator_count: 161
-  - - committee: [32, 379, 45]
-      shard: 450
-      total_validator_count: 161
-  - - committee: [383, 46]
-      shard: 451
-      total_validator_count: 161
-  - - committee: [117, 26, 380]
-      shard: 452
-      total_validator_count: 161
-  - - committee: [364, 205]
-      shard: 453
-      total_validator_count: 161
-  - - committee: [84, 330, 398]
-      shard: 454
-      total_validator_count: 161
-  - - committee: [373, 164]
-      shard: 455
-      total_validator_count: 161
-  - - committee: [315, 104, 293]
-      shard: 456
-      total_validator_count: 161
-  - - committee: [255, 110]
-      shard: 457
-      total_validator_count: 161
-  - - committee: [297, 53, 279]
-      shard: 458
-      total_validator_count: 161
-  - - committee: [122, 160]
-      shard: 459
-      total_validator_count: 161
-  - - committee: [87, 74, 54]
-      shard: 460
-      total_validator_count: 161
-  - - committee: [123, 62]
-      shard: 461
-      total_validator_count: 161
-  - - committee: [7, 295, 258]
-      shard: 462
-      total_validator_count: 161
-  - - committee: [146, 227, 266]
-      shard: 463
-      total_validator_count: 161
-  seed: '0xebeb8f9a88f523bc0d4ce17deee159c9791c919c3d8884187a66935c7af5665e'
+  - [268, 350]
+  - [330, 3]
+  - [74, 303]
+  - [209, 92, 97]
+  - [135, 72]
+  - [295, 139]
+  - [287, 190, 181]
+  - [26, 111]
+  - [101, 307]
+  - [2, 178]
+  - [324, 286, 65]
+  - [227, 162]
+  - [347, 165]
+  - [174, 156, 143]
+  - [175, 298]
+  - [183, 96]
+  - [134, 57, 59]
+  - [304, 153]
+  - [179, 149]
+  - [232, 233]
+  - [204, 203, 15]
+  - [148, 123]
+  - [11, 311]
+  - [19, 225, 224]
+  - [158, 14]
+  - [316, 8]
+  - [337, 167, 39]
+  - [229, 73]
+  - [319, 9]
+  - [121, 292]
+  - [309, 285, 245]
+  - [314, 277]
+  - [243, 235]
+  - [117, 24, 0]
+  - [5, 293]
+  - [12, 176]
+  - [140, 10]
+  - [132, 20, 22]
+  - [193, 145]
+  - [231, 212]
+  - [261, 171, 84]
+  - [82, 32]
+  - [114, 219]
+  - [255, 88, 161]
+  - [1, 211]
+  - [353, 302]
+  - [259, 98]
+  - [343, 107, 228]
+  - [36, 328]
+  - [77, 214]
+  - [185, 44, 95]
+  - [113, 342]
+  - [294, 154]
+  - [170, 320, 48]
+  - [318, 42]
+  - [27, 226]
+  - [47, 79]
+  - [192, 296, 138]
+  - [120, 246]
+  - [83, 7]
+  - [151, 166, 200]
+  - [115, 16]
+  - [118, 262]
+  - [357, 40, 102]
+  seed: '0x803768a7ef49c21203bcf918a124921a48f68646c71db90cfc97a1926f734690'
 - input:
-    crosslinking_start_shard: 669
-    validators_status: [1, 1, 0, 1, 4, 3, 1, 4, 4, 1, 2, 2, 0, 2, 3, 4, 0, 4, 4, 0,
-      4, 3, 3, 2, 4, 2, 3, 2, 1, 4, 1, 1, 4, 1, 2, 0, 0, 4, 4, 4, 3, 4, 0, 0, 3, 1,
-      3, 4, 2, 0, 2, 2, 0, 1, 1, 4, 2, 2, 1, 4, 2, 4, 0, 4, 2, 0, 3, 1, 4, 1, 4, 2,
-      3, 4, 4, 1, 2, 4, 4, 4, 1, 0, 4, 3, 2, 2, 4, 2, 1, 3, 3, 1, 3, 3, 3, 2, 4, 3,
-      4, 4, 0, 0, 3, 4, 4, 2, 3, 3, 1, 2, 3, 4, 1, 1, 4, 4, 1, 2, 3, 4, 1, 0, 0, 0,
-      0, 0, 2, 3, 4, 2, 1, 1, 2, 4, 4, 2, 4, 2, 3, 3, 4, 4, 0, 0, 2, 3, 4, 2, 2, 3,
-      3, 1, 1, 2, 3, 4, 4, 0, 4, 2, 0, 3, 3, 1, 3, 4, 1, 1, 1, 3, 1, 2, 3, 3, 4, 4,
-      1, 4, 4, 1, 4, 0, 4, 1, 0, 4, 0, 3, 3, 1, 0, 0, 2, 1, 2, 4, 4, 1, 2, 4, 2, 1,
-      0, 2, 2, 1, 3, 4, 1, 1, 0, 3, 2, 2, 2, 1, 2, 1, 1, 3, 4, 0, 2, 3, 4, 2, 0, 3,
-      1, 2, 1, 0, 4, 4, 1, 4, 4, 4, 0, 2, 0, 4, 3, 4, 3, 3, 3, 3, 0, 2, 4, 1, 1, 1,
-      3, 3, 0, 3, 3, 3, 3, 3, 4, 1, 1, 1, 3, 3, 3, 1, 1, 1, 1, 3, 0, 3, 4, 0, 4, 4,
-      0, 4, 1, 0, 1, 1, 1, 2, 4, 0, 0, 3, 0, 3, 1, 0, 3, 4, 3, 3, 2, 3, 1, 0, 4, 0,
-      1, 4, 4, 4, 4, 2, 1, 2, 4, 2, 0, 1, 2, 2, 4, 3, 1, 0, 1, 0, 4, 0, 3, 1, 2, 1,
-      0, 3, 3, 4, 4, 1, 0, 0, 1, 0, 4, 3, 3, 2, 2, 3, 3, 0, 0, 4, 2, 3, 3, 4, 1, 0,
-      4, 2, 0, 3, 0, 0, 4, 2, 3, 3, 4, 0, 4, 2, 3, 3, 3, 2, 4, 0, 0, 1, 0, 4, 4, 4]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 238, exit_epoch: 1047, original_index: 0}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 1}
+    - {activation_epoch: 992, exit_epoch: 3772, original_index: 2}
+    - {activation_epoch: 1027, exit_epoch: 1788, original_index: 3}
+    - {activation_epoch: 454, exit_epoch: 964, original_index: 4}
+    - {activation_epoch: 878, exit_epoch: 1074, original_index: 5}
+    - {activation_epoch: 786, exit_epoch: 990, original_index: 6}
+    - {activation_epoch: 645, exit_epoch: 965, original_index: 7}
+    - {activation_epoch: 959, exit_epoch: 18446744073709551615, original_index: 8}
+    - {activation_epoch: 588, exit_epoch: 956, original_index: 9}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 10}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 11}
+    - {activation_epoch: 516, exit_epoch: 962, original_index: 12}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 13}
+    - {activation_epoch: 837, exit_epoch: 1009, original_index: 14}
+    - {activation_epoch: 975, exit_epoch: 18446744073709551615, original_index: 15}
+    - {activation_epoch: 178, exit_epoch: 952, original_index: 16}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 17}
+    - {activation_epoch: 497, exit_epoch: 934, original_index: 18}
+    - {activation_epoch: 113, exit_epoch: 1015, original_index: 19}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 20}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 21}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 22}
+    - {activation_epoch: 612, exit_epoch: 1036, original_index: 23}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 24}
+    - {activation_epoch: 367, exit_epoch: 1022, original_index: 25}
+    - {activation_epoch: 1024, exit_epoch: 4920, original_index: 26}
+    - {activation_epoch: 1022, exit_epoch: 3594, original_index: 27}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 28}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 29}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 30}
+    - {activation_epoch: 44, exit_epoch: 888, original_index: 31}
+    - {activation_epoch: 1021, exit_epoch: 2989, original_index: 32}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 33}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 34}
+    - {activation_epoch: 1006, exit_epoch: 3440, original_index: 35}
+    - {activation_epoch: 120, exit_epoch: 1012, original_index: 36}
+    - {activation_epoch: 972, exit_epoch: 18446744073709551615, original_index: 37}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 39}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 40}
+    - {activation_epoch: 1029, exit_epoch: 4145, original_index: 41}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 42}
+    - {activation_epoch: 989, exit_epoch: 3144, original_index: 43}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 44}
+    - {activation_epoch: 164, exit_epoch: 1022, original_index: 45}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 46}
+    - {activation_epoch: 198, exit_epoch: 949, original_index: 47}
+    - {activation_epoch: 464, exit_epoch: 1006, original_index: 48}
+    - {activation_epoch: 737, exit_epoch: 1055, original_index: 49}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 50}
+    - {activation_epoch: 1037, exit_epoch: 4184, original_index: 51}
+    - {activation_epoch: 999, exit_epoch: 1883, original_index: 52}
+    - {activation_epoch: 75, exit_epoch: 1003, original_index: 53}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 54}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 55}
+    - {activation_epoch: 1053, exit_epoch: 18446744073709551615, original_index: 56}
+    - {activation_epoch: 247, exit_epoch: 983, original_index: 57}
+    - {activation_epoch: 1015, exit_epoch: 4289, original_index: 58}
+    - {activation_epoch: 555, exit_epoch: 998, original_index: 59}
+    - {activation_epoch: 965, exit_epoch: 4962, original_index: 60}
+    - {activation_epoch: 563, exit_epoch: 1019, original_index: 61}
+    - {activation_epoch: 904, exit_epoch: 1014, original_index: 62}
+    - {activation_epoch: 736, exit_epoch: 966, original_index: 63}
+    - {activation_epoch: 60, exit_epoch: 1015, original_index: 64}
+    - {activation_epoch: 967, exit_epoch: 4015, original_index: 65}
+    - {activation_epoch: 977, exit_epoch: 1001, original_index: 66}
+    - {activation_epoch: 1022, exit_epoch: 18446744073709551615, original_index: 67}
+    - {activation_epoch: 442, exit_epoch: 933, original_index: 68}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 69}
+    - {activation_epoch: 60, exit_epoch: 1003, original_index: 70}
+    - {activation_epoch: 460, exit_epoch: 968, original_index: 71}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 72}
+    - {activation_epoch: 399, exit_epoch: 1027, original_index: 73}
+    - {activation_epoch: 1010, exit_epoch: 1038, original_index: 74}
+    - {activation_epoch: 1066, exit_epoch: 1551, original_index: 75}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 76}
+    - {activation_epoch: 842, exit_epoch: 1000, original_index: 77}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 78}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 79}
+    - {activation_epoch: 297, exit_epoch: 983, original_index: 80}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 843, exit_epoch: 1042, original_index: 82}
+    - {activation_epoch: 701, exit_epoch: 1054, original_index: 83}
+    - {activation_epoch: 656, exit_epoch: 1003, original_index: 84}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 85}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 86}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 87}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 88}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 89}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 90}
+    - {activation_epoch: 992, exit_epoch: 3272, original_index: 91}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 92}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 93}
+    - {activation_epoch: 997, exit_epoch: 18446744073709551615, original_index: 94}
+    - {activation_epoch: 941, exit_epoch: 1024, original_index: 95}
+    - {activation_epoch: 1033, exit_epoch: 18446744073709551615, original_index: 96}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 97}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 98}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 99}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 100}
+    - {activation_epoch: 120, exit_epoch: 961, original_index: 101}
+    - {activation_epoch: 880, exit_epoch: 994, original_index: 102}
+    - {activation_epoch: 964, exit_epoch: 3492, original_index: 103}
+    - {activation_epoch: 944, exit_epoch: 1217, original_index: 104}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 105}
+    - {activation_epoch: 988, exit_epoch: 18446744073709551615, original_index: 106}
+    - {activation_epoch: 807, exit_epoch: 994, original_index: 107}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 108}
+    - {activation_epoch: 1007, exit_epoch: 3127, original_index: 109}
+    - {activation_epoch: 557, exit_epoch: 981, original_index: 110}
+    - {activation_epoch: 867, exit_epoch: 1005, original_index: 111}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 112}
+    - {activation_epoch: 97, exit_epoch: 996, original_index: 113}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 114}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 115}
+    - {activation_epoch: 16, exit_epoch: 1015, original_index: 116}
+    - {activation_epoch: 569, exit_epoch: 927, original_index: 117}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 118}
+    - {activation_epoch: 122, exit_epoch: 1062, original_index: 119}
+    - {activation_epoch: 128, exit_epoch: 985, original_index: 120}
+    - {activation_epoch: 935, exit_epoch: 18446744073709551615, original_index: 121}
+    - {activation_epoch: 929, exit_epoch: 1901, original_index: 122}
+    - {activation_epoch: 994, exit_epoch: 1847, original_index: 123}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 124}
+    - {activation_epoch: 923, exit_epoch: 4597, original_index: 125}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 126}
+    - {activation_epoch: 584, exit_epoch: 968, original_index: 127}
+    - {activation_epoch: 22, exit_epoch: 945, original_index: 128}
+    - {activation_epoch: 974, exit_epoch: 4046, original_index: 129}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 130}
+    - {activation_epoch: 599, exit_epoch: 1017, original_index: 131}
+    - {activation_epoch: 971, exit_epoch: 3151, original_index: 132}
+    - {activation_epoch: 1000, exit_epoch: 2817, original_index: 133}
+    - {activation_epoch: 984, exit_epoch: 1906, original_index: 134}
+    - {activation_epoch: 966, exit_epoch: 998, original_index: 135}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 136}
+    - {activation_epoch: 323, exit_epoch: 1074, original_index: 137}
+    - {activation_epoch: 968, exit_epoch: 3585, original_index: 138}
+    - {activation_epoch: 612, exit_epoch: 1009, original_index: 139}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 140}
+    - {activation_epoch: 27, exit_epoch: 947, original_index: 141}
+    - {activation_epoch: 218, exit_epoch: 951, original_index: 142}
+    - {activation_epoch: 870, exit_epoch: 1062, original_index: 143}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 144}
+    - {activation_epoch: 988, exit_epoch: 2157, original_index: 145}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 146}
+    - {activation_epoch: 763, exit_epoch: 962, original_index: 147}
+    - {activation_epoch: 971, exit_epoch: 989, original_index: 148}
+    - {activation_epoch: 1029, exit_epoch: 18446744073709551615, original_index: 149}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 150}
+    - {activation_epoch: 1033, exit_epoch: 18446744073709551615, original_index: 151}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 152}
+    - {activation_epoch: 37, exit_epoch: 1000, original_index: 153}
+    - {activation_epoch: 800, exit_epoch: 984, original_index: 154}
+    - {activation_epoch: 380, exit_epoch: 1015, original_index: 155}
+    - {activation_epoch: 971, exit_epoch: 18446744073709551615, original_index: 156}
+    - {activation_epoch: 991, exit_epoch: 3516, original_index: 157}
+    - {activation_epoch: 1000, exit_epoch: 18446744073709551615, original_index: 158}
+    - {activation_epoch: 997, exit_epoch: 2211, original_index: 159}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 160}
+    - {activation_epoch: 1019, exit_epoch: 18446744073709551615, original_index: 161}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 162}
+    - {activation_epoch: 807, exit_epoch: 1011, original_index: 163}
+    - {activation_epoch: 823, exit_epoch: 998, original_index: 164}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 165}
+    - {activation_epoch: 964, exit_epoch: 1201, original_index: 166}
+    - {activation_epoch: 988, exit_epoch: 4082, original_index: 167}
   output:
-  - - committee: [80, 318]
-      shard: 669
-      total_validator_count: 140
-  - - committee: [215, 205]
-      shard: 670
-      total_validator_count: 140
-  - - committee: [212, 337]
-      shard: 671
-      total_validator_count: 140
-  - - committee: [359, 263]
-      shard: 672
-      total_validator_count: 140
-  - - committee: [228, 53]
-      shard: 673
-      total_validator_count: 140
-  - - committee: [75, 130, 116]
-      shard: 674
-      total_validator_count: 140
-  - - committee: [105, 168]
-      shard: 675
-      total_validator_count: 140
-  - - committee: [269, 147]
-      shard: 676
-      total_validator_count: 140
-  - - committee: [152, 84]
-      shard: 677
-      total_validator_count: 140
-  - - committee: [286, 356]
-      shard: 678
-      total_validator_count: 140
-  - - committee: [270, 306, 129]
-      shard: 679
-      total_validator_count: 140
-  - - committee: [214, 287]
-      shard: 680
-      total_validator_count: 140
-  - - committee: [170, 271]
-      shard: 681
-      total_validator_count: 140
-  - - committee: [252, 315]
-      shard: 682
-      total_validator_count: 140
-  - - committee: [311, 11]
-      shard: 683
-      total_validator_count: 140
-  - - committee: [25, 126, 28]
-      shard: 684
-      total_validator_count: 140
-  - - committee: [91, 132]
-      shard: 685
-      total_validator_count: 140
-  - - committee: [117, 108]
-      shard: 686
-      total_validator_count: 140
-  - - committee: [253, 30]
-      shard: 687
-      total_validator_count: 140
-  - - committee: [151, 120]
-      shard: 688
-      total_validator_count: 140
-  - - committee: [76, 375]
-      shard: 689
-      total_validator_count: 140
-  - - committee: [144, 167, 67]
-      shard: 690
-      total_validator_count: 140
-  - - committee: [112, 131]
-      shard: 691
-      total_validator_count: 140
-  - - committee: [135, 10]
-      shard: 692
-      total_validator_count: 140
-  - - committee: [264, 225]
-      shard: 693
-      total_validator_count: 140
-  - - committee: [284, 213]
-      shard: 694
-      total_validator_count: 140
-  - - committee: [272, 300, 176]
-      shard: 695
-      total_validator_count: 140
-  - - committee: [171, 230]
-      shard: 696
-      total_validator_count: 140
-  - - committee: [198, 345]
-      shard: 697
-      total_validator_count: 140
-  - - committee: [85, 209]
-      shard: 698
-      total_validator_count: 140
-  - - committee: [71, 200]
-      shard: 699
-      total_validator_count: 140
-  - - committee: [69, 302, 189]
-      shard: 700
-      total_validator_count: 140
-  - - committee: [54, 34]
-      shard: 701
-      total_validator_count: 140
-  - - committee: [352, 148]
-      shard: 702
-      total_validator_count: 140
-  - - committee: [317, 282]
-      shard: 703
-      total_validator_count: 140
-  - - committee: [45, 249]
-      shard: 704
-      total_validator_count: 140
-  - - committee: [324, 9]
-      shard: 705
-      total_validator_count: 140
-  - - committee: [87, 153, 340]
-      shard: 706
-      total_validator_count: 140
-  - - committee: [6, 3]
-      shard: 707
-      total_validator_count: 140
-  - - committee: [13, 204]
-      shard: 708
-      total_validator_count: 140
-  - - committee: [179, 48]
-      shard: 709
-      total_validator_count: 140
-  - - committee: [60, 58]
-      shard: 710
-      total_validator_count: 140
-  - - committee: [113, 294, 312]
-      shard: 711
-      total_validator_count: 140
-  - - committee: [88, 0]
-      shard: 712
-      total_validator_count: 140
-  - - committee: [56, 166]
-      shard: 713
-      total_validator_count: 140
-  - - committee: [346, 208]
-      shard: 714
-      total_validator_count: 140
-  - - committee: [51, 27]
-      shard: 715
-      total_validator_count: 140
-  - - committee: [229, 193, 313]
-      shard: 716
-      total_validator_count: 140
-  - - committee: [203, 197]
-      shard: 717
-      total_validator_count: 140
-  - - committee: [194, 239]
-      shard: 718
-      total_validator_count: 140
-  - - committee: [109, 330]
-      shard: 719
-      total_validator_count: 140
-  - - committee: [163, 95]
-      shard: 720
-      total_validator_count: 140
-  - - committee: [371, 1]
-      shard: 721
-      total_validator_count: 140
-  - - committee: [234, 329, 183]
-      shard: 722
-      total_validator_count: 140
-  - - committee: [365, 31]
-      shard: 723
-      total_validator_count: 140
-  - - committee: [251, 23]
-      shard: 724
-      total_validator_count: 140
-  - - committee: [57, 159]
-      shard: 725
-      total_validator_count: 140
-  - - committee: [379, 322]
-      shard: 726
-      total_validator_count: 140
-  - - committee: [222, 285, 33]
-      shard: 727
-      total_validator_count: 140
-  - - committee: [192, 217]
-      shard: 728
-      total_validator_count: 140
-  - - committee: [64, 265]
-      shard: 729
-      total_validator_count: 140
-  - - committee: [331, 137]
-      shard: 730
-      total_validator_count: 140
-  - - committee: [50, 201]
-      shard: 731
-      total_validator_count: 140
-  - - committee: [216, 319, 218]
-      shard: 732
-      total_validator_count: 140
-  seed: '0x6ff9fde4cd621a9359ee5f08929d2188ed5f72b59aa71c3d10453ccde114d1b6'
+  - []
+  - [121]
+  - [133]
+  - [52]
+  - [158]
+  - [45]
+  - [156]
+  - [129]
+  - [166]
+  - [61]
+  - [43]
+  - [91]
+  - [155]
+  - [37]
+  - [143]
+  - [2]
+  - [139]
+  - [116]
+  - [138]
+  - [65]
+  - [122]
+  - []
+  - [15]
+  - [145]
+  - [64]
+  - [36]
+  - [62]
+  - [167]
+  - [119]
+  - [83]
+  - [103]
+  - [163]
+  - [82]
+  - [106]
+  - [111]
+  - [165]
+  - [60]
+  - [25]
+  - [123]
+  - [159]
+  - [66]
+  - [0]
+  - []
+  - [104]
+  - [94]
+  - [131]
+  - [157]
+  - [134]
+  - [70]
+  - [95]
+  - [137]
+  - [23]
+  - [14]
+  - [125]
+  - [53]
+  - [152]
+  - [84]
+  - [8]
+  - [48]
+  - [19]
+  - [132]
+  - [73]
+  - [5]
+  - [49]
+  seed: '0x8541f5c60ed01f0514d4aa7b0426a78c9868da6b4b781e55435615d47a80d87e'
 - input:
-    crosslinking_start_shard: 946
-    validators_status: [2, 2, 1, 4, 1, 1, 0, 4, 4, 1, 0, 1, 4, 0, 2, 0, 2, 0, 3, 1,
-      2, 4, 4, 1, 4, 2, 3, 4, 4, 3, 2, 3, 0, 0, 1, 0, 0, 2, 0, 1, 4, 1, 3, 0, 0, 4,
-      0, 0, 1, 1, 1, 4, 3, 1, 2, 0, 1, 1, 1, 4, 1, 3, 1, 1, 3, 4, 4, 3, 4, 1, 1, 0,
-      3, 4, 0, 1, 0, 2, 2, 3, 0, 4, 4, 0, 2, 0, 2, 0, 0, 0, 2, 3, 2, 3, 3, 0, 2, 1,
-      0, 0, 4, 4, 4, 1, 2, 3, 3, 0, 1, 0, 1, 1, 2, 3, 1, 2, 4, 3, 0, 0, 3, 2, 1, 1,
-      0, 2, 0, 3, 0, 2, 1, 3, 4, 0, 3, 4, 2, 4, 3, 0, 1, 1, 2, 2, 3, 0, 0, 2, 3, 1,
-      3, 4, 3, 1, 4, 2, 0, 4, 4, 2, 0, 0, 1, 2, 4, 2, 1, 0, 3, 2, 0, 3, 0, 3, 0, 3,
-      0, 1, 0, 4, 4, 0, 4, 0, 2, 2, 2, 4, 1, 2, 4, 2, 4, 1, 0, 0, 2, 3, 3, 3, 1, 1,
-      2, 4, 1, 4, 0, 2, 2, 0, 0, 2, 4, 2, 1, 4, 2, 0, 1, 0, 3, 1, 1, 1, 3, 4, 3, 0,
-      1, 0, 2, 3, 3, 1, 4, 1, 3, 0, 3, 1, 2, 2, 4, 2, 2, 1, 1, 4, 1, 4, 3, 4, 3, 1,
-      4, 2, 4, 0, 0, 2, 0, 4, 0, 1, 3, 4, 1, 4, 1, 4, 2, 2, 3, 1, 2, 2, 1, 4, 2, 4,
-      2, 4, 1, 2, 4, 3, 1, 0, 2, 0, 2, 2, 4, 0, 1, 1, 2, 0, 4, 1, 1, 2, 1, 3, 3, 1,
-      3, 1, 4, 2, 0, 3, 3, 2, 2, 0, 3, 2, 2, 1, 4, 3, 3, 0, 2, 4, 2, 4, 1, 3, 2, 0,
-      0, 4, 0, 0, 2, 1, 4, 4, 4, 2, 4, 3, 4, 4, 4, 3, 2, 0, 1, 4, 3, 2, 3, 2, 0, 3,
-      3, 1, 3, 1, 2, 0, 0, 2, 4, 0, 1, 2, 1, 4, 1, 2, 2, 2, 1, 2, 2, 0, 1, 0, 1, 0,
-      1, 2, 1, 2, 1, 4, 2, 2, 1, 4, 2, 4, 1, 2, 1, 4, 0, 1, 2, 0, 3, 1, 2, 1, 2, 3,
-      0, 0, 2, 0, 2, 0, 4, 0, 2, 3, 1, 4, 2, 3, 0, 2, 0, 3, 4, 4, 2, 3, 1, 2, 2, 2,
-      4, 4, 2, 3, 0, 0, 3, 0, 3, 3, 3, 3, 3, 0, 2, 2, 1, 0, 0, 1, 1, 1, 4, 3]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 1041, exit_epoch: 3570, original_index: 0}
+    - {activation_epoch: 1017, exit_epoch: 4402, original_index: 1}
+    - {activation_epoch: 1036, exit_epoch: 3784, original_index: 2}
+    - {activation_epoch: 915, exit_epoch: 986, original_index: 3}
+    - {activation_epoch: 990, exit_epoch: 2822, original_index: 4}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 5}
+    - {activation_epoch: 565, exit_epoch: 978, original_index: 6}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 7}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 8}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 9}
+    - {activation_epoch: 1042, exit_epoch: 18446744073709551615, original_index: 10}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 11}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 12}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 13}
+    - {activation_epoch: 1022, exit_epoch: 18446744073709551615, original_index: 14}
+    - {activation_epoch: 1061, exit_epoch: 1919, original_index: 15}
+    - {activation_epoch: 220, exit_epoch: 964, original_index: 16}
+    - {activation_epoch: 95, exit_epoch: 1017, original_index: 17}
+    - {activation_epoch: 983, exit_epoch: 1045, original_index: 18}
+    - {activation_epoch: 630, exit_epoch: 990, original_index: 19}
+    - {activation_epoch: 371, exit_epoch: 990, original_index: 20}
+    - {activation_epoch: 981, exit_epoch: 18446744073709551615, original_index: 21}
+    - {activation_epoch: 963, exit_epoch: 18446744073709551615, original_index: 22}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 23}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 24}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 25}
+    - {activation_epoch: 298, exit_epoch: 1041, original_index: 26}
+    - {activation_epoch: 133, exit_epoch: 979, original_index: 27}
+    - {activation_epoch: 804, exit_epoch: 1036, original_index: 28}
+    - {activation_epoch: 1008, exit_epoch: 1013, original_index: 29}
+    - {activation_epoch: 1043, exit_epoch: 3017, original_index: 30}
+    - {activation_epoch: 971, exit_epoch: 3107, original_index: 31}
+    - {activation_epoch: 1047, exit_epoch: 1410, original_index: 32}
+    - {activation_epoch: 459, exit_epoch: 948, original_index: 33}
+    - {activation_epoch: 141, exit_epoch: 1035, original_index: 34}
+    - {activation_epoch: 493, exit_epoch: 966, original_index: 35}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 36}
+    - {activation_epoch: 981, exit_epoch: 1802, original_index: 37}
+    - {activation_epoch: 974, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 66, exit_epoch: 1014, original_index: 39}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 40}
+    - {activation_epoch: 1033, exit_epoch: 3757, original_index: 41}
+    - {activation_epoch: 775, exit_epoch: 1030, original_index: 42}
+    - {activation_epoch: 960, exit_epoch: 3367, original_index: 43}
+    - {activation_epoch: 961, exit_epoch: 1448, original_index: 44}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 45}
+    - {activation_epoch: 793, exit_epoch: 994, original_index: 46}
+    - {activation_epoch: 985, exit_epoch: 2869, original_index: 47}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 48}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 49}
+    - {activation_epoch: 888, exit_epoch: 993, original_index: 50}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 51}
+    - {activation_epoch: 37, exit_epoch: 964, original_index: 52}
+    - {activation_epoch: 541, exit_epoch: 1008, original_index: 53}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 54}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 55}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 56}
+    - {activation_epoch: 1040, exit_epoch: 18446744073709551615, original_index: 57}
+    - {activation_epoch: 757, exit_epoch: 969, original_index: 58}
+    - {activation_epoch: 1006, exit_epoch: 2016, original_index: 59}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 60}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 61}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 62}
+    - {activation_epoch: 353, exit_epoch: 947, original_index: 63}
+    - {activation_epoch: 922, exit_epoch: 18446744073709551615, original_index: 64}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 65}
+    - {activation_epoch: 677, exit_epoch: 960, original_index: 66}
+    - {activation_epoch: 577, exit_epoch: 1025, original_index: 67}
+    - {activation_epoch: 461, exit_epoch: 986, original_index: 68}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 69}
+    - {activation_epoch: 160, exit_epoch: 963, original_index: 70}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 71}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 72}
+    - {activation_epoch: 978, exit_epoch: 1007, original_index: 73}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 74}
+    - {activation_epoch: 220, exit_epoch: 994, original_index: 75}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 76}
+    - {activation_epoch: 786, exit_epoch: 1038, original_index: 77}
+    - {activation_epoch: 444, exit_epoch: 976, original_index: 78}
+    - {activation_epoch: 360, exit_epoch: 968, original_index: 79}
+    - {activation_epoch: 654, exit_epoch: 1003, original_index: 80}
+    - {activation_epoch: 765, exit_epoch: 948, original_index: 81}
+    - {activation_epoch: 1034, exit_epoch: 18446744073709551615, original_index: 82}
+    - {activation_epoch: 992, exit_epoch: 3561, original_index: 83}
+    - {activation_epoch: 1052, exit_epoch: 3770, original_index: 84}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 85}
+    - {activation_epoch: 985, exit_epoch: 2415, original_index: 86}
+    - {activation_epoch: 717, exit_epoch: 1008, original_index: 87}
+    - {activation_epoch: 50, exit_epoch: 983, original_index: 88}
+    - {activation_epoch: 270, exit_epoch: 997, original_index: 89}
+    - {activation_epoch: 783, exit_epoch: 992, original_index: 90}
+    - {activation_epoch: 986, exit_epoch: 3933, original_index: 91}
+    - {activation_epoch: 976, exit_epoch: 18446744073709551615, original_index: 92}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 93}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 94}
+    - {activation_epoch: 179, exit_epoch: 1049, original_index: 95}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 96}
+    - {activation_epoch: 1039, exit_epoch: 18446744073709551615, original_index: 97}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 98}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 99}
+    - {activation_epoch: 133, exit_epoch: 990, original_index: 100}
+    - {activation_epoch: 939, exit_epoch: 3431, original_index: 101}
+    - {activation_epoch: 213, exit_epoch: 1009, original_index: 102}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 103}
+    - {activation_epoch: 1048, exit_epoch: 2923, original_index: 104}
+    - {activation_epoch: 820, exit_epoch: 1037, original_index: 105}
+    - {activation_epoch: 991, exit_epoch: 18446744073709551615, original_index: 106}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 107}
+    - {activation_epoch: 969, exit_epoch: 3488, original_index: 108}
+    - {activation_epoch: 955, exit_epoch: 18446744073709551615, original_index: 109}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 110}
+    - {activation_epoch: 1061, exit_epoch: 18446744073709551615, original_index: 111}
+    - {activation_epoch: 1000, exit_epoch: 18446744073709551615, original_index: 112}
+    - {activation_epoch: 878, exit_epoch: 996, original_index: 113}
+    - {activation_epoch: 1071, exit_epoch: 3728, original_index: 114}
+    - {activation_epoch: 583, exit_epoch: 982, original_index: 115}
+    - {activation_epoch: 1028, exit_epoch: 1299, original_index: 116}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 117}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 118}
+    - {activation_epoch: 697, exit_epoch: 1041, original_index: 119}
+    - {activation_epoch: 1024, exit_epoch: 2232, original_index: 120}
+    - {activation_epoch: 957, exit_epoch: 4877, original_index: 121}
+    - {activation_epoch: 523, exit_epoch: 959, original_index: 122}
+    - {activation_epoch: 495, exit_epoch: 1014, original_index: 123}
+    - {activation_epoch: 347, exit_epoch: 1009, original_index: 124}
+    - {activation_epoch: 855, exit_epoch: 1015, original_index: 125}
+    - {activation_epoch: 949, exit_epoch: 2829, original_index: 126}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 127}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 128}
+    - {activation_epoch: 989, exit_epoch: 1207, original_index: 129}
+    - {activation_epoch: 1035, exit_epoch: 3562, original_index: 130}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 131}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 132}
+    - {activation_epoch: 915, exit_epoch: 4270, original_index: 133}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 134}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 135}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 136}
+    - {activation_epoch: 556, exit_epoch: 984, original_index: 137}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 138}
+    - {activation_epoch: 951, exit_epoch: 959, original_index: 139}
+    - {activation_epoch: 734, exit_epoch: 999, original_index: 140}
+    - {activation_epoch: 969, exit_epoch: 1819, original_index: 141}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 142}
+    - {activation_epoch: 640, exit_epoch: 1055, original_index: 143}
+    - {activation_epoch: 1012, exit_epoch: 3751, original_index: 144}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 145}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 146}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 147}
+    - {activation_epoch: 598, exit_epoch: 957, original_index: 148}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 149}
+    - {activation_epoch: 904, exit_epoch: 986, original_index: 150}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 151}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 152}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 153}
+    - {activation_epoch: 271, exit_epoch: 1000, original_index: 154}
+    - {activation_epoch: 21, exit_epoch: 1033, original_index: 155}
+    - {activation_epoch: 76, exit_epoch: 1036, original_index: 156}
+    - {activation_epoch: 196, exit_epoch: 1028, original_index: 157}
+    - {activation_epoch: 898, exit_epoch: 964, original_index: 158}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 159}
+    - {activation_epoch: 984, exit_epoch: 18446744073709551615, original_index: 160}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 161}
+    - {activation_epoch: 271, exit_epoch: 1024, original_index: 162}
+    - {activation_epoch: 383, exit_epoch: 978, original_index: 163}
+    - {activation_epoch: 732, exit_epoch: 998, original_index: 164}
+    - {activation_epoch: 558, exit_epoch: 1032, original_index: 165}
+    - {activation_epoch: 971, exit_epoch: 1012, original_index: 166}
+    - {activation_epoch: 48, exit_epoch: 957, original_index: 167}
+    - {activation_epoch: 1004, exit_epoch: 1103, original_index: 168}
+    - {activation_epoch: 968, exit_epoch: 2832, original_index: 169}
+    - {activation_epoch: 809, exit_epoch: 990, original_index: 170}
+    - {activation_epoch: 979, exit_epoch: 1006, original_index: 171}
+    - {activation_epoch: 657, exit_epoch: 995, original_index: 172}
+    - {activation_epoch: 355, exit_epoch: 1042, original_index: 173}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 174}
+    - {activation_epoch: 937, exit_epoch: 4518, original_index: 175}
+    - {activation_epoch: 775, exit_epoch: 1005, original_index: 176}
+    - {activation_epoch: 778, exit_epoch: 949, original_index: 177}
+    - {activation_epoch: 322, exit_epoch: 1051, original_index: 178}
+    - {activation_epoch: 680, exit_epoch: 1066, original_index: 179}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 180}
+    - {activation_epoch: 650, exit_epoch: 1038, original_index: 181}
+    - {activation_epoch: 548, exit_epoch: 1040, original_index: 182}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 183}
+    - {activation_epoch: 404, exit_epoch: 962, original_index: 184}
+    - {activation_epoch: 375, exit_epoch: 998, original_index: 185}
+    - {activation_epoch: 954, exit_epoch: 3816, original_index: 186}
+    - {activation_epoch: 1030, exit_epoch: 18446744073709551615, original_index: 187}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 188}
+    - {activation_epoch: 341, exit_epoch: 1032, original_index: 189}
+    - {activation_epoch: 479, exit_epoch: 957, original_index: 190}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 191}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 192}
+    - {activation_epoch: 944, exit_epoch: 18446744073709551615, original_index: 193}
+    - {activation_epoch: 984, exit_epoch: 3424, original_index: 194}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 195}
+    - {activation_epoch: 86, exit_epoch: 969, original_index: 196}
+    - {activation_epoch: 652, exit_epoch: 1050, original_index: 197}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 198}
+    - {activation_epoch: 932, exit_epoch: 983, original_index: 199}
+    - {activation_epoch: 1054, exit_epoch: 4684, original_index: 200}
+    - {activation_epoch: 1035, exit_epoch: 18446744073709551615, original_index: 201}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 202}
+    - {activation_epoch: 313, exit_epoch: 993, original_index: 203}
+    - {activation_epoch: 1037, exit_epoch: 18446744073709551615, original_index: 204}
+    - {activation_epoch: 1058, exit_epoch: 18446744073709551615, original_index: 205}
+    - {activation_epoch: 132, exit_epoch: 1018, original_index: 206}
+    - {activation_epoch: 120, exit_epoch: 1041, original_index: 207}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 208}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 209}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 210}
+    - {activation_epoch: 0, exit_epoch: 1040, original_index: 211}
+    - {activation_epoch: 1022, exit_epoch: 18446744073709551615, original_index: 212}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 213}
+    - {activation_epoch: 918, exit_epoch: 18446744073709551615, original_index: 214}
+    - {activation_epoch: 560, exit_epoch: 1074, original_index: 215}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 216}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 217}
+    - {activation_epoch: 393, exit_epoch: 994, original_index: 218}
+    - {activation_epoch: 961, exit_epoch: 18446744073709551615, original_index: 219}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 220}
+    - {activation_epoch: 451, exit_epoch: 990, original_index: 221}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 222}
+    - {activation_epoch: 108, exit_epoch: 968, original_index: 223}
+    - {activation_epoch: 363, exit_epoch: 1016, original_index: 224}
+    - {activation_epoch: 989, exit_epoch: 2971, original_index: 225}
+    - {activation_epoch: 285, exit_epoch: 1017, original_index: 226}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 227}
+    - {activation_epoch: 122, exit_epoch: 1018, original_index: 228}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 229}
+    - {activation_epoch: 1045, exit_epoch: 4974, original_index: 230}
+    - {activation_epoch: 485, exit_epoch: 1036, original_index: 231}
+    - {activation_epoch: 870, exit_epoch: 972, original_index: 232}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 233}
+    - {activation_epoch: 1054, exit_epoch: 18446744073709551615, original_index: 234}
+    - {activation_epoch: 944, exit_epoch: 3363, original_index: 235}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 236}
+    - {activation_epoch: 968, exit_epoch: 18446744073709551615, original_index: 237}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 238}
+    - {activation_epoch: 400, exit_epoch: 1000, original_index: 239}
+    - {activation_epoch: 1005, exit_epoch: 3922, original_index: 240}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 241}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 242}
+    - {activation_epoch: 966, exit_epoch: 1165, original_index: 243}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 244}
+    - {activation_epoch: 304, exit_epoch: 1030, original_index: 245}
+    - {activation_epoch: 147, exit_epoch: 996, original_index: 246}
+    - {activation_epoch: 1021, exit_epoch: 4247, original_index: 247}
+    - {activation_epoch: 1005, exit_epoch: 1450, original_index: 248}
+    - {activation_epoch: 970, exit_epoch: 1511, original_index: 249}
+    - {activation_epoch: 901, exit_epoch: 1044, original_index: 250}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 251}
+    - {activation_epoch: 922, exit_epoch: 1060, original_index: 252}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 253}
+    - {activation_epoch: 828, exit_epoch: 1084, original_index: 254}
+    - {activation_epoch: 942, exit_epoch: 1769, original_index: 255}
+    - {activation_epoch: 1047, exit_epoch: 18446744073709551615, original_index: 256}
+    - {activation_epoch: 935, exit_epoch: 4129, original_index: 257}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 258}
+    - {activation_epoch: 982, exit_epoch: 986, original_index: 259}
+    - {activation_epoch: 732, exit_epoch: 925, original_index: 260}
+    - {activation_epoch: 414, exit_epoch: 1002, original_index: 261}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 262}
+    - {activation_epoch: 763, exit_epoch: 1053, original_index: 263}
+    - {activation_epoch: 58, exit_epoch: 1003, original_index: 264}
+    - {activation_epoch: 740, exit_epoch: 1053, original_index: 265}
+    - {activation_epoch: 828, exit_epoch: 959, original_index: 266}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 267}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 268}
+    - {activation_epoch: 1053, exit_epoch: 18446744073709551615, original_index: 269}
+    - {activation_epoch: 954, exit_epoch: 18446744073709551615, original_index: 270}
+    - {activation_epoch: 1007, exit_epoch: 1488, original_index: 271}
+    - {activation_epoch: 152, exit_epoch: 1051, original_index: 272}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 273}
+    - {activation_epoch: 215, exit_epoch: 955, original_index: 274}
+    - {activation_epoch: 1009, exit_epoch: 2652, original_index: 275}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 276}
+    - {activation_epoch: 1030, exit_epoch: 1608, original_index: 277}
+    - {activation_epoch: 726, exit_epoch: 1034, original_index: 278}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 279}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 280}
+    - {activation_epoch: 997, exit_epoch: 1367, original_index: 281}
+    - {activation_epoch: 292, exit_epoch: 1020, original_index: 282}
+    - {activation_epoch: 1011, exit_epoch: 3978, original_index: 283}
+    - {activation_epoch: 1041, exit_epoch: 4646, original_index: 284}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 285}
+    - {activation_epoch: 1009, exit_epoch: 1032, original_index: 286}
+    - {activation_epoch: 477, exit_epoch: 1021, original_index: 287}
+    - {activation_epoch: 1049, exit_epoch: 2716, original_index: 288}
+    - {activation_epoch: 1089, exit_epoch: 18446744073709551615, original_index: 289}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 290}
+    - {activation_epoch: 1036, exit_epoch: 2665, original_index: 291}
+    - {activation_epoch: 520, exit_epoch: 1011, original_index: 292}
+    - {activation_epoch: 584, exit_epoch: 1011, original_index: 293}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 294}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 295}
+    - {activation_epoch: 977, exit_epoch: 2055, original_index: 296}
+    - {activation_epoch: 921, exit_epoch: 1926, original_index: 297}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 298}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 299}
+    - {activation_epoch: 1071, exit_epoch: 2213, original_index: 300}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 301}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 302}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 303}
+    - {activation_epoch: 969, exit_epoch: 3483, original_index: 304}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 305}
+    - {activation_epoch: 737, exit_epoch: 1001, original_index: 306}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 307}
+    - {activation_epoch: 250, exit_epoch: 978, original_index: 308}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 309}
+    - {activation_epoch: 1040, exit_epoch: 4946, original_index: 310}
+    - {activation_epoch: 625, exit_epoch: 1000, original_index: 311}
+    - {activation_epoch: 668, exit_epoch: 1010, original_index: 312}
+    - {activation_epoch: 1041, exit_epoch: 18446744073709551615, original_index: 313}
+    - {activation_epoch: 412, exit_epoch: 969, original_index: 314}
+    - {activation_epoch: 24, exit_epoch: 970, original_index: 315}
+    - {activation_epoch: 1020, exit_epoch: 3706, original_index: 316}
+    - {activation_epoch: 107, exit_epoch: 1016, original_index: 317}
+    - {activation_epoch: 1046, exit_epoch: 1261, original_index: 318}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 319}
+    - {activation_epoch: 1017, exit_epoch: 1041, original_index: 320}
+    - {activation_epoch: 274, exit_epoch: 1005, original_index: 321}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 322}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 323}
+    - {activation_epoch: 823, exit_epoch: 983, original_index: 324}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 325}
+    - {activation_epoch: 931, exit_epoch: 18446744073709551615, original_index: 326}
+    - {activation_epoch: 363, exit_epoch: 1010, original_index: 327}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 328}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 329}
+    - {activation_epoch: 715, exit_epoch: 1042, original_index: 330}
+    - {activation_epoch: 1030, exit_epoch: 1098, original_index: 331}
+    - {activation_epoch: 909, exit_epoch: 1036, original_index: 332}
+    - {activation_epoch: 987, exit_epoch: 2404, original_index: 333}
+    - {activation_epoch: 983, exit_epoch: 18446744073709551615, original_index: 334}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 335}
+    - {activation_epoch: 538, exit_epoch: 1002, original_index: 336}
+    - {activation_epoch: 544, exit_epoch: 955, original_index: 337}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 338}
+    - {activation_epoch: 515, exit_epoch: 977, original_index: 339}
+    - {activation_epoch: 975, exit_epoch: 2378, original_index: 340}
+    - {activation_epoch: 965, exit_epoch: 1489, original_index: 341}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 342}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 343}
+    - {activation_epoch: 994, exit_epoch: 3630, original_index: 344}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 345}
+    - {activation_epoch: 963, exit_epoch: 18446744073709551615, original_index: 346}
+    - {activation_epoch: 64, exit_epoch: 977, original_index: 347}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 348}
+    - {activation_epoch: 318, exit_epoch: 995, original_index: 349}
+    - {activation_epoch: 781, exit_epoch: 974, original_index: 350}
+    - {activation_epoch: 560, exit_epoch: 965, original_index: 351}
+    - {activation_epoch: 514, exit_epoch: 1030, original_index: 352}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 353}
+    - {activation_epoch: 783, exit_epoch: 949, original_index: 354}
+    - {activation_epoch: 43, exit_epoch: 989, original_index: 355}
+    - {activation_epoch: 445, exit_epoch: 965, original_index: 356}
+    - {activation_epoch: 959, exit_epoch: 1417, original_index: 357}
+    - {activation_epoch: 1029, exit_epoch: 18446744073709551615, original_index: 358}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 359}
+    - {activation_epoch: 974, exit_epoch: 18446744073709551615, original_index: 360}
+    - {activation_epoch: 826, exit_epoch: 978, original_index: 361}
+    - {activation_epoch: 780, exit_epoch: 1018, original_index: 362}
+    - {activation_epoch: 937, exit_epoch: 18446744073709551615, original_index: 363}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 364}
+    - {activation_epoch: 535, exit_epoch: 979, original_index: 365}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 366}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 367}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 368}
+    - {activation_epoch: 462, exit_epoch: 1058, original_index: 369}
+    - {activation_epoch: 148, exit_epoch: 999, original_index: 370}
+    - {activation_epoch: 300, exit_epoch: 1010, original_index: 371}
+    - {activation_epoch: 308, exit_epoch: 978, original_index: 372}
+    - {activation_epoch: 409, exit_epoch: 1024, original_index: 373}
+    - {activation_epoch: 133, exit_epoch: 982, original_index: 374}
   output:
-  - - committee: [30, 166, 163]
-      shard: 946
-      total_validator_count: 202
-  - - committee: [130, 412, 382]
-      shard: 947
-      total_validator_count: 202
-  - - committee: [104, 69, 361]
-      shard: 948
-      total_validator_count: 202
-  - - committee: [228, 218, 314]
-      shard: 949
-      total_validator_count: 202
-  - - committee: [300, 452, 184]
-      shard: 950
-      total_validator_count: 202
-  - - committee: [90, 112, 386]
-      shard: 951
-      total_validator_count: 202
-  - - committee: [213, 108, 142, 318]
-      shard: 952
-      total_validator_count: 202
-  - - committee: [96, 39, 309]
-      shard: 953
-      total_validator_count: 202
-  - - committee: [401, 222, 355]
-      shard: 954
-      total_validator_count: 202
-  - - committee: [239, 77, 396]
-      shard: 955
-      total_validator_count: 202
-  - - committee: [123, 211, 58]
-      shard: 956
-      total_validator_count: 202
-  - - committee: [41, 177, 301]
-      shard: 957
-      total_validator_count: 202
-  - - committee: [392, 141, 97, 201]
-      shard: 958
-      total_validator_count: 202
-  - - committee: [299, 422, 48]
-      shard: 959
-      total_validator_count: 202
-  - - committee: [394, 305, 283]
-      shard: 960
-      total_validator_count: 202
-  - - committee: [387, 189, 16]
-      shard: 961
-      total_validator_count: 202
-  - - committee: [365, 380, 223]
-      shard: 962
-      total_validator_count: 202
-  - - committee: [84, 270, 149]
-      shard: 963
-      total_validator_count: 202
-  - - committee: [230, 49, 25]
-      shard: 964
-      total_validator_count: 202
-  - - committee: [60, 397, 11, 143]
-      shard: 965
-      total_validator_count: 202
-  - - committee: [2, 185, 271]
-      shard: 966
-      total_validator_count: 202
-  - - committee: [235, 336, 263]
-      shard: 967
-      total_validator_count: 202
-  - - committee: [246, 433, 216]
-      shard: 968
-      total_validator_count: 202
-  - - committee: [398, 317, 350]
-      shard: 969
-      total_validator_count: 202
-  - - committee: [359, 324, 313]
-      shard: 970
-      total_validator_count: 202
-  - - committee: [282, 408, 268, 70]
-      shard: 971
-      total_validator_count: 202
-  - - committee: [385, 368, 418]
-      shard: 972
-      total_validator_count: 202
-  - - committee: [214, 341, 253]
-      shard: 973
-      total_validator_count: 202
-  - - committee: [165, 295, 376]
-      shard: 974
-      total_validator_count: 202
-  - - committee: [186, 191, 319]
-      shard: 975
-      total_validator_count: 202
-  - - committee: [362, 378, 425]
-      shard: 976
-      total_validator_count: 202
-  - - committee: [9, 147, 302, 155]
-      shard: 977
-      total_validator_count: 202
-  - - committee: [115, 456, 414]
-      shard: 978
-      total_validator_count: 202
-  - - committee: [37, 373, 50]
-      shard: 979
-      total_validator_count: 202
-  - - committee: [153, 202, 57]
-      shard: 980
-      total_validator_count: 202
-  - - committee: [14, 129, 240]
-      shard: 981
-      total_validator_count: 202
-  - - committee: [326, 4, 455]
-      shard: 982
-      total_validator_count: 202
-  - - committee: [259, 407, 438]
-      shard: 983
-      total_validator_count: 202
-  - - committee: [374, 377, 451, 188]
-      shard: 984
-      total_validator_count: 202
-  - - committee: [384, 420, 274]
-      shard: 985
-      total_validator_count: 202
-  - - committee: [56, 233, 288]
-      shard: 986
-      total_validator_count: 202
-  - - committee: [290, 54, 1]
-      shard: 987
-      total_validator_count: 202
-  - - committee: [294, 432, 169]
-      shard: 988
-      total_validator_count: 202
-  - - committee: [159, 275, 375]
-      shard: 989
-      total_validator_count: 202
-  - - committee: [125, 78, 196, 278]
-      shard: 990
-      total_validator_count: 202
-  - - committee: [255, 221, 5]
-      shard: 991
-      total_validator_count: 202
-  - - committee: [162, 114, 207]
-      shard: 992
-      total_validator_count: 202
-  - - committee: [103, 430, 140]
-      shard: 993
-      total_validator_count: 202
-  - - committee: [286, 53, 200]
-      shard: 994
-      total_validator_count: 202
-  - - committee: [273, 372, 434]
-      shard: 995
-      total_validator_count: 202
-  - - committee: [369, 245, 328]
-      shard: 996
-      total_validator_count: 202
-  - - committee: [307, 276, 193, 244]
-      shard: 997
-      total_validator_count: 202
-  - - committee: [23, 34, 391]
-      shard: 998
-      total_validator_count: 202
-  - - committee: [241, 63, 19]
-      shard: 999
-      total_validator_count: 202
-  - - committee: [136, 435, 457]
-      shard: 1000
-      total_validator_count: 202
-  - - committee: [92, 348, 86]
-      shard: 1001
-      total_validator_count: 202
-  - - committee: [370, 406, 243]
-      shard: 1002
-      total_validator_count: 202
-  - - committee: [330, 296, 337, 353]
-      shard: 1003
-      total_validator_count: 202
-  - - committee: [111, 390, 20]
-      shard: 1004
-      total_validator_count: 202
-  - - committee: [266, 450, 402]
-      shard: 1005
-      total_validator_count: 202
-  - - committee: [208, 405, 388]
-      shard: 1006
-      total_validator_count: 202
-  - - committee: [121, 62, 204]
-      shard: 1007
-      total_validator_count: 202
-  - - committee: [122, 248, 110]
-      shard: 1008
-      total_validator_count: 202
-  - - committee: [291, 0, 75, 280]
-      shard: 1009
-      total_validator_count: 202
-  seed: '0x9d162fc672c9aba987488027bea4cbc77375dc5ab7c620ce42b3bb35f1445aa8'
+  - [109, 215]
+  - [173, 211]
+  - [254, 83]
+  - [47, 72]
+  - [142, 334]
+  - [306, 38, 281]
+  - [257, 102]
+  - [165, 106]
+  - [105, 127]
+  - [214, 272]
+  - [155, 18]
+  - [160, 312, 207]
+  - [141, 42]
+  - [26, 176]
+  - [69, 175]
+  - [237, 373]
+  - [86, 125]
+  - [131, 22, 321]
+  - [363, 323]
+  - [37, 336]
+  - [193, 124]
+  - [67, 255]
+  - [34, 228]
+  - [162, 332, 166]
+  - [95, 326]
+  - [261, 64]
+  - [186, 293]
+  - [278, 344]
+  - [101, 151]
+  - [330, 31, 108]
+  - [126, 39]
+  - [80, 197]
+  - [182, 206]
+  - [77, 231]
+  - [138, 243, 303]
+  - [341, 296]
+  - [225, 123]
+  - [360, 219]
+  - [119, 327]
+  - [112, 252]
+  - [216, 73, 43]
+  - [249, 264]
+  - [17, 263]
+  - [53, 292]
+  - [333, 128]
+  - [282, 362]
+  - [129, 357, 135]
+  - [352, 369]
+  - [28, 340]
+  - [179, 224]
+  - [44, 157]
+  - [178, 270]
+  - [371, 297, 265]
+  - [171, 226]
+  - [87, 302]
+  - [21, 181]
+  - [235, 304]
+  - [156, 92]
+  - [194, 250, 287]
+  - [143, 4]
+  - [348, 121]
+  - [169, 346]
+  - [245, 317]
+  - [189, 91, 133]
+  seed: '0x8100355b22adc7e9d02dff05dd14e746a629cf22f185aa9957f0db957cec7187'
 - input:
-    crosslinking_start_shard: 378
-    validators_status: [0, 0, 1, 2, 0, 1, 4, 0, 0, 2, 1, 4, 3, 4, 1, 4, 2, 2, 3, 3,
-      4, 0, 0, 3, 3, 3, 1, 0, 1, 2, 2, 4, 1, 3, 4, 2, 3, 3, 4, 1, 1, 2, 1, 2, 3, 3,
-      0, 0, 3, 4, 3, 3, 4, 0, 1, 2, 3, 0, 2, 3, 2, 4, 0, 3, 2, 4, 3, 4, 4, 3, 0, 2,
-      1, 2, 4, 3, 2, 2, 1, 3, 2, 4, 1, 1, 0, 1, 4, 2, 3, 4, 1, 1, 0, 4, 4, 3, 4, 4,
-      3, 3, 3, 3, 3, 3, 0, 1, 4, 4, 0, 2, 4, 3, 2, 0, 1, 3, 2, 0, 1, 4, 2, 0, 0, 4,
-      2, 2, 1, 0, 2, 4, 1, 3, 1, 4, 3, 4, 4, 4, 1, 0, 4, 1, 0, 4, 1, 2, 2, 4, 4, 2,
-      0, 2, 3, 3, 4, 1, 4, 0, 3, 1, 0, 0, 2, 0, 1, 3, 3, 3, 3, 1, 2, 3, 0, 2, 4, 1,
-      1, 1, 3, 2, 0, 3, 3, 1]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 967, exit_epoch: 18446744073709551615, original_index: 0}
+    - {activation_epoch: 968, exit_epoch: 983, original_index: 1}
+    - {activation_epoch: 1028, exit_epoch: 4244, original_index: 2}
+    - {activation_epoch: 124, exit_epoch: 985, original_index: 3}
+    - {activation_epoch: 831, exit_epoch: 1036, original_index: 4}
+    - {activation_epoch: 838, exit_epoch: 957, original_index: 5}
+    - {activation_epoch: 1047, exit_epoch: 3268, original_index: 6}
+    - {activation_epoch: 942, exit_epoch: 1020, original_index: 7}
+    - {activation_epoch: 994, exit_epoch: 1069, original_index: 8}
+    - {activation_epoch: 172, exit_epoch: 1005, original_index: 9}
+    - {activation_epoch: 981, exit_epoch: 4569, original_index: 10}
+    - {activation_epoch: 961, exit_epoch: 968, original_index: 11}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 12}
+    - {activation_epoch: 312, exit_epoch: 1026, original_index: 13}
+    - {activation_epoch: 976, exit_epoch: 18446744073709551615, original_index: 14}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 15}
+    - {activation_epoch: 650, exit_epoch: 973, original_index: 16}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 17}
+    - {activation_epoch: 1029, exit_epoch: 3930, original_index: 18}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 19}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 20}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 21}
+    - {activation_epoch: 376, exit_epoch: 981, original_index: 22}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 23}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 24}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 25}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 26}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 27}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 28}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 29}
+    - {activation_epoch: 863, exit_epoch: 1017, original_index: 30}
+    - {activation_epoch: 12, exit_epoch: 1014, original_index: 31}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 32}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 33}
+    - {activation_epoch: 970, exit_epoch: 18446744073709551615, original_index: 34}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 35}
+    - {activation_epoch: 793, exit_epoch: 1034, original_index: 36}
+    - {activation_epoch: 937, exit_epoch: 2393, original_index: 37}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 1029, exit_epoch: 1209, original_index: 39}
+    - {activation_epoch: 217, exit_epoch: 1065, original_index: 40}
+    - {activation_epoch: 823, exit_epoch: 987, original_index: 41}
+    - {activation_epoch: 1010, exit_epoch: 4305, original_index: 42}
+    - {activation_epoch: 1004, exit_epoch: 3371, original_index: 43}
+    - {activation_epoch: 1041, exit_epoch: 2480, original_index: 44}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 45}
+    - {activation_epoch: 725, exit_epoch: 959, original_index: 46}
+    - {activation_epoch: 355, exit_epoch: 953, original_index: 47}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 48}
+    - {activation_epoch: 955, exit_epoch: 2462, original_index: 49}
+    - {activation_epoch: 198, exit_epoch: 987, original_index: 50}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 51}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 52}
+    - {activation_epoch: 940, exit_epoch: 996, original_index: 53}
+    - {activation_epoch: 420, exit_epoch: 997, original_index: 54}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 55}
+    - {activation_epoch: 764, exit_epoch: 1040, original_index: 56}
+    - {activation_epoch: 1006, exit_epoch: 1421, original_index: 57}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 58}
+    - {activation_epoch: 1019, exit_epoch: 18446744073709551615, original_index: 59}
+    - {activation_epoch: 944, exit_epoch: 1327, original_index: 60}
+    - {activation_epoch: 864, exit_epoch: 968, original_index: 61}
+    - {activation_epoch: 508, exit_epoch: 1061, original_index: 62}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 63}
+    - {activation_epoch: 30, exit_epoch: 931, original_index: 64}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 65}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 66}
+    - {activation_epoch: 564, exit_epoch: 1010, original_index: 67}
+    - {activation_epoch: 1030, exit_epoch: 18446744073709551615, original_index: 68}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 69}
+    - {activation_epoch: 804, exit_epoch: 961, original_index: 70}
+    - {activation_epoch: 832, exit_epoch: 1011, original_index: 71}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 72}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 73}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 74}
+    - {activation_epoch: 264, exit_epoch: 1032, original_index: 75}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 76}
+    - {activation_epoch: 1004, exit_epoch: 1279, original_index: 77}
+    - {activation_epoch: 265, exit_epoch: 1015, original_index: 78}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 79}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 80}
+    - {activation_epoch: 961, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 840, exit_epoch: 976, original_index: 82}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 83}
+    - {activation_epoch: 1037, exit_epoch: 1049, original_index: 84}
+    - {activation_epoch: 945, exit_epoch: 3594, original_index: 85}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 86}
+    - {activation_epoch: 1044, exit_epoch: 1580, original_index: 87}
+    - {activation_epoch: 753, exit_epoch: 1033, original_index: 88}
+    - {activation_epoch: 943, exit_epoch: 18446744073709551615, original_index: 89}
+    - {activation_epoch: 971, exit_epoch: 1014, original_index: 90}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 91}
+    - {activation_epoch: 979, exit_epoch: 18446744073709551615, original_index: 92}
+    - {activation_epoch: 563, exit_epoch: 996, original_index: 93}
+    - {activation_epoch: 115, exit_epoch: 993, original_index: 94}
+    - {activation_epoch: 848, exit_epoch: 944, original_index: 95}
+    - {activation_epoch: 743, exit_epoch: 994, original_index: 96}
+    - {activation_epoch: 882, exit_epoch: 1014, original_index: 97}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 98}
+    - {activation_epoch: 1058, exit_epoch: 18446744073709551615, original_index: 99}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 100}
+    - {activation_epoch: 123, exit_epoch: 1046, original_index: 101}
+    - {activation_epoch: 104, exit_epoch: 971, original_index: 102}
+    - {activation_epoch: 818, exit_epoch: 969, original_index: 103}
+    - {activation_epoch: 903, exit_epoch: 985, original_index: 104}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 105}
+    - {activation_epoch: 146, exit_epoch: 1000, original_index: 106}
+    - {activation_epoch: 1049, exit_epoch: 18446744073709551615, original_index: 107}
+    - {activation_epoch: 66, exit_epoch: 972, original_index: 108}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 109}
+    - {activation_epoch: 673, exit_epoch: 1029, original_index: 110}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 111}
+    - {activation_epoch: 941, exit_epoch: 4236, original_index: 112}
+    - {activation_epoch: 921, exit_epoch: 974, original_index: 113}
+    - {activation_epoch: 1008, exit_epoch: 3923, original_index: 114}
+    - {activation_epoch: 713, exit_epoch: 1016, original_index: 115}
+    - {activation_epoch: 951, exit_epoch: 18446744073709551615, original_index: 116}
+    - {activation_epoch: 1020, exit_epoch: 18446744073709551615, original_index: 117}
+    - {activation_epoch: 993, exit_epoch: 18446744073709551615, original_index: 118}
+    - {activation_epoch: 1001, exit_epoch: 1011, original_index: 119}
+    - {activation_epoch: 1030, exit_epoch: 1913, original_index: 120}
+    - {activation_epoch: 218, exit_epoch: 954, original_index: 121}
+    - {activation_epoch: 984, exit_epoch: 4561, original_index: 122}
+    - {activation_epoch: 702, exit_epoch: 986, original_index: 123}
+    - {activation_epoch: 500, exit_epoch: 996, original_index: 124}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 125}
+    - {activation_epoch: 495, exit_epoch: 952, original_index: 126}
+    - {activation_epoch: 255, exit_epoch: 1012, original_index: 127}
+    - {activation_epoch: 207, exit_epoch: 1029, original_index: 128}
+    - {activation_epoch: 1031, exit_epoch: 2292, original_index: 129}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 130}
+    - {activation_epoch: 1008, exit_epoch: 18446744073709551615, original_index: 131}
+    - {activation_epoch: 441, exit_epoch: 935, original_index: 132}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 133}
+    - {activation_epoch: 93, exit_epoch: 982, original_index: 134}
+    - {activation_epoch: 899, exit_epoch: 986, original_index: 135}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 136}
+    - {activation_epoch: 950, exit_epoch: 996, original_index: 137}
+    - {activation_epoch: 657, exit_epoch: 1016, original_index: 138}
+    - {activation_epoch: 40, exit_epoch: 999, original_index: 139}
+    - {activation_epoch: 964, exit_epoch: 3044, original_index: 140}
+    - {activation_epoch: 322, exit_epoch: 988, original_index: 141}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 142}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 143}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 144}
+    - {activation_epoch: 67, exit_epoch: 1038, original_index: 145}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 146}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 147}
+    - {activation_epoch: 588, exit_epoch: 972, original_index: 148}
+    - {activation_epoch: 997, exit_epoch: 18446744073709551615, original_index: 149}
+    - {activation_epoch: 290, exit_epoch: 1015, original_index: 150}
+    - {activation_epoch: 412, exit_epoch: 1014, original_index: 151}
+    - {activation_epoch: 419, exit_epoch: 991, original_index: 152}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 153}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 154}
+    - {activation_epoch: 751, exit_epoch: 932, original_index: 155}
+    - {activation_epoch: 414, exit_epoch: 984, original_index: 156}
+    - {activation_epoch: 97, exit_epoch: 950, original_index: 157}
+    - {activation_epoch: 172, exit_epoch: 956, original_index: 158}
+    - {activation_epoch: 1022, exit_epoch: 1812, original_index: 159}
+    - {activation_epoch: 259, exit_epoch: 999, original_index: 160}
+    - {activation_epoch: 993, exit_epoch: 18446744073709551615, original_index: 161}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 162}
+    - {activation_epoch: 826, exit_epoch: 1005, original_index: 163}
+    - {activation_epoch: 29, exit_epoch: 977, original_index: 164}
+    - {activation_epoch: 1059, exit_epoch: 4310, original_index: 165}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 166}
+    - {activation_epoch: 98, exit_epoch: 1011, original_index: 167}
+    - {activation_epoch: 449, exit_epoch: 1029, original_index: 168}
+    - {activation_epoch: 310, exit_epoch: 1001, original_index: 169}
+    - {activation_epoch: 1015, exit_epoch: 4191, original_index: 170}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 171}
+    - {activation_epoch: 218, exit_epoch: 991, original_index: 172}
+    - {activation_epoch: 957, exit_epoch: 18446744073709551615, original_index: 173}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 174}
+    - {activation_epoch: 535, exit_epoch: 1041, original_index: 175}
+    - {activation_epoch: 1051, exit_epoch: 18446744073709551615, original_index: 176}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 177}
+    - {activation_epoch: 990, exit_epoch: 18446744073709551615, original_index: 178}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 179}
+    - {activation_epoch: 986, exit_epoch: 1094, original_index: 180}
+    - {activation_epoch: 139, exit_epoch: 961, original_index: 181}
+    - {activation_epoch: 263, exit_epoch: 983, original_index: 182}
+    - {activation_epoch: 1018, exit_epoch: 18446744073709551615, original_index: 183}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 184}
+    - {activation_epoch: 969, exit_epoch: 18446744073709551615, original_index: 185}
+    - {activation_epoch: 700, exit_epoch: 1036, original_index: 186}
+    - {activation_epoch: 993, exit_epoch: 18446744073709551615, original_index: 187}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 188}
+    - {activation_epoch: 1007, exit_epoch: 1138, original_index: 189}
+    - {activation_epoch: 1031, exit_epoch: 18446744073709551615, original_index: 190}
+    - {activation_epoch: 773, exit_epoch: 963, original_index: 191}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 192}
+    - {activation_epoch: 728, exit_epoch: 1043, original_index: 193}
+    - {activation_epoch: 1036, exit_epoch: 18446744073709551615, original_index: 194}
+    - {activation_epoch: 81, exit_epoch: 1035, original_index: 195}
+    - {activation_epoch: 621, exit_epoch: 956, original_index: 196}
+    - {activation_epoch: 998, exit_epoch: 3079, original_index: 197}
+    - {activation_epoch: 638, exit_epoch: 947, original_index: 198}
+    - {activation_epoch: 964, exit_epoch: 1035, original_index: 199}
+    - {activation_epoch: 1015, exit_epoch: 18446744073709551615, original_index: 200}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 201}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 202}
+    - {activation_epoch: 517, exit_epoch: 1046, original_index: 203}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 204}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 205}
+    - {activation_epoch: 1023, exit_epoch: 4381, original_index: 206}
+    - {activation_epoch: 1047, exit_epoch: 3156, original_index: 207}
+    - {activation_epoch: 1033, exit_epoch: 4844, original_index: 208}
+    - {activation_epoch: 124, exit_epoch: 1018, original_index: 209}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 210}
+    - {activation_epoch: 1026, exit_epoch: 1041, original_index: 211}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 212}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 213}
+    - {activation_epoch: 549, exit_epoch: 919, original_index: 214}
+    - {activation_epoch: 997, exit_epoch: 1374, original_index: 215}
+    - {activation_epoch: 105, exit_epoch: 1031, original_index: 216}
+    - {activation_epoch: 1010, exit_epoch: 4197, original_index: 217}
+    - {activation_epoch: 857, exit_epoch: 938, original_index: 218}
+    - {activation_epoch: 1017, exit_epoch: 3855, original_index: 219}
+    - {activation_epoch: 964, exit_epoch: 2379, original_index: 220}
+    - {activation_epoch: 928, exit_epoch: 3401, original_index: 221}
+    - {activation_epoch: 1034, exit_epoch: 4680, original_index: 222}
+    - {activation_epoch: 982, exit_epoch: 3801, original_index: 223}
+    - {activation_epoch: 66, exit_epoch: 1032, original_index: 224}
+    - {activation_epoch: 870, exit_epoch: 1004, original_index: 225}
+    - {activation_epoch: 1022, exit_epoch: 3482, original_index: 226}
+    - {activation_epoch: 986, exit_epoch: 18446744073709551615, original_index: 227}
+    - {activation_epoch: 1014, exit_epoch: 18446744073709551615, original_index: 228}
+    - {activation_epoch: 341, exit_epoch: 999, original_index: 229}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 230}
+    - {activation_epoch: 679, exit_epoch: 1016, original_index: 231}
+    - {activation_epoch: 266, exit_epoch: 964, original_index: 232}
+    - {activation_epoch: 305, exit_epoch: 975, original_index: 233}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 234}
+    - {activation_epoch: 980, exit_epoch: 4546, original_index: 235}
+    - {activation_epoch: 963, exit_epoch: 3701, original_index: 236}
+    - {activation_epoch: 715, exit_epoch: 902, original_index: 237}
+    - {activation_epoch: 946, exit_epoch: 978, original_index: 238}
+    - {activation_epoch: 241, exit_epoch: 972, original_index: 239}
+    - {activation_epoch: 438, exit_epoch: 1041, original_index: 240}
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 241}
+    - {activation_epoch: 964, exit_epoch: 18446744073709551615, original_index: 242}
+    - {activation_epoch: 458, exit_epoch: 1024, original_index: 243}
+    - {activation_epoch: 88, exit_epoch: 1024, original_index: 244}
+    - {activation_epoch: 1034, exit_epoch: 2606, original_index: 245}
+    - {activation_epoch: 13, exit_epoch: 1042, original_index: 246}
+    - {activation_epoch: 918, exit_epoch: 18446744073709551615, original_index: 247}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 248}
+    - {activation_epoch: 581, exit_epoch: 1037, original_index: 249}
+    - {activation_epoch: 967, exit_epoch: 3686, original_index: 250}
+    - {activation_epoch: 1010, exit_epoch: 2447, original_index: 251}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 252}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 253}
+    - {activation_epoch: 427, exit_epoch: 940, original_index: 254}
+    - {activation_epoch: 958, exit_epoch: 18446744073709551615, original_index: 255}
+    - {activation_epoch: 962, exit_epoch: 18446744073709551615, original_index: 256}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 257}
+    - {activation_epoch: 678, exit_epoch: 1058, original_index: 258}
+    - {activation_epoch: 928, exit_epoch: 1026, original_index: 259}
+    - {activation_epoch: 115, exit_epoch: 1071, original_index: 260}
+    - {activation_epoch: 955, exit_epoch: 18446744073709551615, original_index: 261}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 262}
+    - {activation_epoch: 560, exit_epoch: 911, original_index: 263}
+    - {activation_epoch: 1023, exit_epoch: 18446744073709551615, original_index: 264}
+    - {activation_epoch: 251, exit_epoch: 967, original_index: 265}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 266}
+    - {activation_epoch: 287, exit_epoch: 1052, original_index: 267}
+    - {activation_epoch: 498, exit_epoch: 946, original_index: 268}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 269}
+    - {activation_epoch: 940, exit_epoch: 2736, original_index: 270}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 271}
+    - {activation_epoch: 999, exit_epoch: 18446744073709551615, original_index: 272}
+    - {activation_epoch: 964, exit_epoch: 18446744073709551615, original_index: 273}
+    - {activation_epoch: 991, exit_epoch: 4980, original_index: 274}
+    - {activation_epoch: 998, exit_epoch: 4417, original_index: 275}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 276}
+    - {activation_epoch: 799, exit_epoch: 1001, original_index: 277}
+    - {activation_epoch: 981, exit_epoch: 4309, original_index: 278}
+    - {activation_epoch: 329, exit_epoch: 995, original_index: 279}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 280}
+    - {activation_epoch: 537, exit_epoch: 1044, original_index: 281}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 282}
+    - {activation_epoch: 1007, exit_epoch: 1034, original_index: 283}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 284}
+    - {activation_epoch: 937, exit_epoch: 1444, original_index: 285}
+    - {activation_epoch: 300, exit_epoch: 983, original_index: 286}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 287}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 288}
+    - {activation_epoch: 1002, exit_epoch: 3477, original_index: 289}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 290}
+    - {activation_epoch: 66, exit_epoch: 1016, original_index: 291}
+    - {activation_epoch: 987, exit_epoch: 18446744073709551615, original_index: 292}
+    - {activation_epoch: 1020, exit_epoch: 18446744073709551615, original_index: 293}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 294}
+    - {activation_epoch: 1068, exit_epoch: 4917, original_index: 295}
+    - {activation_epoch: 109, exit_epoch: 1023, original_index: 296}
+    - {activation_epoch: 212, exit_epoch: 1046, original_index: 297}
+    - {activation_epoch: 913, exit_epoch: 1038, original_index: 298}
+    - {activation_epoch: 978, exit_epoch: 18446744073709551615, original_index: 299}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 300}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 301}
+    - {activation_epoch: 1004, exit_epoch: 2362, original_index: 302}
+    - {activation_epoch: 950, exit_epoch: 4459, original_index: 303}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 304}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 305}
+    - {activation_epoch: 952, exit_epoch: 18446744073709551615, original_index: 306}
+    - {activation_epoch: 834, exit_epoch: 996, original_index: 307}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 308}
+    - {activation_epoch: 0, exit_epoch: 1004, original_index: 309}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 310}
+    - {activation_epoch: 706, exit_epoch: 984, original_index: 311}
+    - {activation_epoch: 518, exit_epoch: 1056, original_index: 312}
+    - {activation_epoch: 1014, exit_epoch: 1049, original_index: 313}
+    - {activation_epoch: 1032, exit_epoch: 1247, original_index: 314}
+    - {activation_epoch: 985, exit_epoch: 3470, original_index: 315}
+    - {activation_epoch: 556, exit_epoch: 1017, original_index: 316}
+    - {activation_epoch: 500, exit_epoch: 1011, original_index: 317}
+    - {activation_epoch: 78, exit_epoch: 1045, original_index: 318}
+    - {activation_epoch: 997, exit_epoch: 3344, original_index: 319}
+    - {activation_epoch: 68, exit_epoch: 995, original_index: 320}
+    - {activation_epoch: 884, exit_epoch: 964, original_index: 321}
+    - {activation_epoch: 296, exit_epoch: 1010, original_index: 322}
+    - {activation_epoch: 590, exit_epoch: 975, original_index: 323}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 324}
+    - {activation_epoch: 922, exit_epoch: 953, original_index: 325}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 326}
+    - {activation_epoch: 237, exit_epoch: 1046, original_index: 327}
+    - {activation_epoch: 869, exit_epoch: 1050, original_index: 328}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 329}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 330}
+    - {activation_epoch: 705, exit_epoch: 1026, original_index: 331}
+    - {activation_epoch: 6, exit_epoch: 1025, original_index: 332}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 333}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 334}
+    - {activation_epoch: 86, exit_epoch: 988, original_index: 335}
+    - {activation_epoch: 1054, exit_epoch: 4770, original_index: 336}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 337}
+    - {activation_epoch: 967, exit_epoch: 18446744073709551615, original_index: 338}
+    - {activation_epoch: 414, exit_epoch: 927, original_index: 339}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 340}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 341}
+    - {activation_epoch: 992, exit_epoch: 2905, original_index: 342}
+    - {activation_epoch: 701, exit_epoch: 1022, original_index: 343}
+    - {activation_epoch: 977, exit_epoch: 1264, original_index: 344}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 345}
+    - {activation_epoch: 377, exit_epoch: 1024, original_index: 346}
+    - {activation_epoch: 941, exit_epoch: 958, original_index: 347}
+    - {activation_epoch: 391, exit_epoch: 1042, original_index: 348}
+    - {activation_epoch: 765, exit_epoch: 1028, original_index: 349}
+    - {activation_epoch: 372, exit_epoch: 999, original_index: 350}
+    - {activation_epoch: 705, exit_epoch: 1016, original_index: 351}
+    - {activation_epoch: 714, exit_epoch: 1024, original_index: 352}
+    - {activation_epoch: 1019, exit_epoch: 18446744073709551615, original_index: 353}
+    - {activation_epoch: 267, exit_epoch: 999, original_index: 354}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 355}
+    - {activation_epoch: 1047, exit_epoch: 18446744073709551615, original_index: 356}
+    - {activation_epoch: 970, exit_epoch: 18446744073709551615, original_index: 357}
+    - {activation_epoch: 1020, exit_epoch: 18446744073709551615, original_index: 358}
+    - {activation_epoch: 969, exit_epoch: 18446744073709551615, original_index: 359}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 360}
+    - {activation_epoch: 504, exit_epoch: 1014, original_index: 361}
+    - {activation_epoch: 967, exit_epoch: 4846, original_index: 362}
+    - {activation_epoch: 964, exit_epoch: 18446744073709551615, original_index: 363}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 364}
+    - {activation_epoch: 668, exit_epoch: 983, original_index: 365}
+    - {activation_epoch: 642, exit_epoch: 988, original_index: 366}
+    - {activation_epoch: 993, exit_epoch: 4573, original_index: 367}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 368}
+    - {activation_epoch: 924, exit_epoch: 2500, original_index: 369}
+    - {activation_epoch: 979, exit_epoch: 2809, original_index: 370}
+    - {activation_epoch: 624, exit_epoch: 982, original_index: 371}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 372}
+    - {activation_epoch: 337, exit_epoch: 981, original_index: 373}
+    - {activation_epoch: 933, exit_epoch: 18446744073709551615, original_index: 374}
+    - {activation_epoch: 530, exit_epoch: 1089, original_index: 375}
+    - {activation_epoch: 982, exit_epoch: 2471, original_index: 376}
+    - {activation_epoch: 222, exit_epoch: 1031, original_index: 377}
+    - {activation_epoch: 73, exit_epoch: 1044, original_index: 378}
+    - {activation_epoch: 903, exit_epoch: 998, original_index: 379}
+    - {activation_epoch: 308, exit_epoch: 1004, original_index: 380}
+    - {activation_epoch: 648, exit_epoch: 959, original_index: 381}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 382}
+    - {activation_epoch: 606, exit_epoch: 1007, original_index: 383}
+    - {activation_epoch: 371, exit_epoch: 1012, original_index: 384}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 385}
+    - {activation_epoch: 981, exit_epoch: 18446744073709551615, original_index: 386}
+    - {activation_epoch: 943, exit_epoch: 1542, original_index: 387}
+    - {activation_epoch: 993, exit_epoch: 3333, original_index: 388}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 389}
+    - {activation_epoch: 827, exit_epoch: 1076, original_index: 390}
+    - {activation_epoch: 610, exit_epoch: 985, original_index: 391}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 392}
+    - {activation_epoch: 1059, exit_epoch: 18446744073709551615, original_index: 393}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 394}
+    - {activation_epoch: 758, exit_epoch: 1027, original_index: 395}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 396}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 397}
+    - {activation_epoch: 968, exit_epoch: 3839, original_index: 398}
+    - {activation_epoch: 986, exit_epoch: 18446744073709551615, original_index: 399}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 400}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 401}
+    - {activation_epoch: 322, exit_epoch: 982, original_index: 402}
+    - {activation_epoch: 389, exit_epoch: 999, original_index: 403}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 404}
+    - {activation_epoch: 1015, exit_epoch: 3219, original_index: 405}
+    - {activation_epoch: 906, exit_epoch: 1030, original_index: 406}
+    - {activation_epoch: 468, exit_epoch: 942, original_index: 407}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 408}
+    - {activation_epoch: 56, exit_epoch: 1070, original_index: 409}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 410}
+    - {activation_epoch: 293, exit_epoch: 1040, original_index: 411}
+    - {activation_epoch: 13, exit_epoch: 997, original_index: 412}
+    - {activation_epoch: 1017, exit_epoch: 1699, original_index: 413}
+    - {activation_epoch: 788, exit_epoch: 977, original_index: 414}
+    - {activation_epoch: 982, exit_epoch: 1000, original_index: 415}
+    - {activation_epoch: 292, exit_epoch: 988, original_index: 416}
+    - {activation_epoch: 1058, exit_epoch: 3166, original_index: 417}
+    - {activation_epoch: 978, exit_epoch: 4586, original_index: 418}
+    - {activation_epoch: 937, exit_epoch: 990, original_index: 419}
+    - {activation_epoch: 758, exit_epoch: 1034, original_index: 420}
+    - {activation_epoch: 966, exit_epoch: 2792, original_index: 421}
+    - {activation_epoch: 441, exit_epoch: 993, original_index: 422}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 423}
+    - {activation_epoch: 951, exit_epoch: 18446744073709551615, original_index: 424}
+    - {activation_epoch: 826, exit_epoch: 1013, original_index: 425}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 426}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 427}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 428}
+    - {activation_epoch: 920, exit_epoch: 4548, original_index: 429}
+    - {activation_epoch: 1029, exit_epoch: 18446744073709551615, original_index: 430}
+    - {activation_epoch: 1039, exit_epoch: 18446744073709551615, original_index: 431}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 432}
+    - {activation_epoch: 985, exit_epoch: 18446744073709551615, original_index: 433}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 434}
+    - {activation_epoch: 210, exit_epoch: 969, original_index: 435}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 436}
+    - {activation_epoch: 500, exit_epoch: 1012, original_index: 437}
+    - {activation_epoch: 80, exit_epoch: 1032, original_index: 438}
+    - {activation_epoch: 845, exit_epoch: 984, original_index: 439}
+    - {activation_epoch: 1020, exit_epoch: 18446744073709551615, original_index: 440}
+    - {activation_epoch: 640, exit_epoch: 987, original_index: 441}
+    - {activation_epoch: 227, exit_epoch: 968, original_index: 442}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 443}
+    - {activation_epoch: 53, exit_epoch: 929, original_index: 444}
+    - {activation_epoch: 60, exit_epoch: 1010, original_index: 445}
+    - {activation_epoch: 375, exit_epoch: 1014, original_index: 446}
+    - {activation_epoch: 1038, exit_epoch: 18446744073709551615, original_index: 447}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 448}
+    - {activation_epoch: 929, exit_epoch: 3085, original_index: 449}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 450}
+    - {activation_epoch: 29, exit_epoch: 1031, original_index: 451}
+    - {activation_epoch: 146, exit_epoch: 1004, original_index: 452}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 453}
+    - {activation_epoch: 376, exit_epoch: 1050, original_index: 454}
+    - {activation_epoch: 579, exit_epoch: 1037, original_index: 455}
+    - {activation_epoch: 1011, exit_epoch: 18446744073709551615, original_index: 456}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 457}
+    - {activation_epoch: 1029, exit_epoch: 1048, original_index: 458}
+    - {activation_epoch: 994, exit_epoch: 2275, original_index: 459}
+    - {activation_epoch: 691, exit_epoch: 1004, original_index: 460}
   output:
-  - - committee: [169]
-      shard: 378
-      total_validator_count: 69
-  - - committee: [125]
-      shard: 379
-      total_validator_count: 69
-  - - committee: [73]
-      shard: 380
-      total_validator_count: 69
-  - - committee: [183]
-      shard: 381
-      total_validator_count: 69
-  - - committee: [41]
-      shard: 382
-      total_validator_count: 69
-  - - committee: [2]
-      shard: 383
-      total_validator_count: 69
-  - - committee: [164]
-      shard: 384
-      total_validator_count: 69
-  - - committee: [28]
-      shard: 385
-      total_validator_count: 69
-  - - committee: [14]
-      shard: 386
-      total_validator_count: 69
-  - - committee: [151]
-      shard: 387
-      total_validator_count: 69
-  - - committee: [175]
-      shard: 388
-      total_validator_count: 69
-  - - committee: [91]
-      shard: 389
-      total_validator_count: 69
-  - - committee: [26, 120]
-      shard: 390
-      total_validator_count: 69
-  - - committee: [162]
-      shard: 391
-      total_validator_count: 69
-  - - committee: [170]
-      shard: 392
-      total_validator_count: 69
-  - - committee: [77]
-      shard: 393
-      total_validator_count: 69
-  - - committee: [30]
-      shard: 394
-      total_validator_count: 69
-  - - committee: [16]
-      shard: 395
-      total_validator_count: 69
-  - - committee: [71]
-      shard: 396
-      total_validator_count: 69
-  - - committee: [83]
-      shard: 397
-      total_validator_count: 69
-  - - committee: [149]
-      shard: 398
-      total_validator_count: 69
-  - - committee: [176]
-      shard: 399
-      total_validator_count: 69
-  - - committee: [55]
-      shard: 400
-      total_validator_count: 69
-  - - committee: [32]
-      shard: 401
-      total_validator_count: 69
-  - - committee: [105]
-      shard: 402
-      total_validator_count: 69
-  - - committee: [128, 39]
-      shard: 403
-      total_validator_count: 69
-  - - committee: [145]
-      shard: 404
-      total_validator_count: 69
-  - - committee: [112]
-      shard: 405
-      total_validator_count: 69
-  - - committee: [159]
-      shard: 406
-      total_validator_count: 69
-  - - committee: [43]
-      shard: 407
-      total_validator_count: 69
-  - - committee: [90]
-      shard: 408
-      total_validator_count: 69
-  - - committee: [126]
-      shard: 409
-      total_validator_count: 69
-  - - committee: [173]
-      shard: 410
-      total_validator_count: 69
-  - - committee: [9]
-      shard: 411
-      total_validator_count: 69
-  - - committee: [132]
-      shard: 412
-      total_validator_count: 69
-  - - committee: [109]
-      shard: 413
-      total_validator_count: 69
-  - - committee: [146]
-      shard: 414
-      total_validator_count: 69
-  - - committee: [130]
-      shard: 415
-      total_validator_count: 69
-  - - committee: [29, 155]
-      shard: 416
-      total_validator_count: 69
-  - - committee: [124]
-      shard: 417
-      total_validator_count: 69
-  - - committee: [80]
-      shard: 418
-      total_validator_count: 69
-  - - committee: [3]
-      shard: 419
-      total_validator_count: 69
-  - - committee: [35]
-      shard: 420
-      total_validator_count: 69
-  - - committee: [177]
-      shard: 421
-      total_validator_count: 69
-  - - committee: [179]
-      shard: 422
-      total_validator_count: 69
-  - - committee: [87]
-      shard: 423
-      total_validator_count: 69
-  - - committee: [17]
-      shard: 424
-      total_validator_count: 69
-  - - committee: [82]
-      shard: 425
-      total_validator_count: 69
-  - - committee: [118]
-      shard: 426
-      total_validator_count: 69
-  - - committee: [42]
-      shard: 427
-      total_validator_count: 69
-  - - committee: [141]
-      shard: 428
-      total_validator_count: 69
-  - - committee: [54, 72]
-      shard: 429
-      total_validator_count: 69
-  - - committee: [138]
-      shard: 430
-      total_validator_count: 69
-  - - committee: [58]
-      shard: 431
-      total_validator_count: 69
-  - - committee: [5]
-      shard: 432
-      total_validator_count: 69
-  - - committee: [64]
-      shard: 433
-      total_validator_count: 69
-  - - committee: [78]
-      shard: 434
-      total_validator_count: 69
-  - - committee: [60]
-      shard: 435
-      total_validator_count: 69
-  - - committee: [144]
-      shard: 436
-      total_validator_count: 69
-  - - committee: [116]
-      shard: 437
-      total_validator_count: 69
-  - - committee: [10]
-      shard: 438
-      total_validator_count: 69
-  - - committee: [76]
-      shard: 439
-      total_validator_count: 69
-  - - committee: [85]
-      shard: 440
-      total_validator_count: 69
-  - - committee: [114, 40]
-      shard: 441
-      total_validator_count: 69
-  seed: '0xa2cb43c505d74fc9e1af073c677665072308dd06142430203c242aba27ca1da5'
+  - [167, 377]
+  - [298, 255, 332]
+  - [195, 454, 455]
+  - [378, 174, 215]
+  - [376, 256]
+  - [242, 285, 327]
+  - [349, 34, 56]
+  - [374, 180, 351]
+  - [175, 40, 370]
+  - [138, 173]
+  - [161, 433, 149]
+  - [88, 359, 303]
+  - [223, 92, 110]
+  - [306, 240]
+  - [316, 421, 362]
+  - [333, 384, 395]
+  - [315, 277, 235]
+  - [275, 399, 185]
+  - [140, 318]
+  - [38, 220, 438]
+  - [449, 49, 89]
+  - [67, 97, 168]
+  - [236, 212]
+  - [387, 145, 118]
+  - [342, 37, 394]
+  - [418, 406, 0]
+  - [363, 231, 346]
+  - [425, 273]
+  - [352, 72, 169]
+  - [388, 14, 187]
+  - [348, 338, 13]
+  - [437, 209, 420]
+  - [424, 452]
+  - [386, 274, 178]
+  - [281, 259, 369]
+  - [7, 390, 216]
+  - [344, 101]
+  - [291, 331, 203]
+  - [4, 247, 9]
+  - [100, 62, 297]
+  - [243, 270, 115]
+  - [343, 267]
+  - [116, 411, 227]
+  - [296, 225, 246]
+  - [78, 36, 221]
+  - [122, 163]
+  - [317, 151, 328]
+  - [278, 409, 312]
+  - [10, 60, 199]
+  - [446, 81, 85]
+  - [31, 8]
+  - [367, 197, 127]
+  - [459, 71, 451]
+  - [380, 112, 193]
+  - [361, 261]
+  - [75, 30, 250]
+  - [357, 272, 258]
+  - [460, 429, 445]
+  - [249, 90, 128]
+  - [383, 309]
+  - [224, 322, 260]
+  - [150, 244, 186]
+  - [375, 398, 271]
+  - [299, 292, 319]
+  seed: '0x26c19211a29406a1958b5a6fce9f74b02e7767bb4218d8450580888ecb87acbc'
 - input:
-    crosslinking_start_shard: 986
-    validators_status: [0, 4, 2, 2, 0, 3, 3, 0, 4, 0, 1, 3, 3, 2, 3, 3, 2, 1, 4, 4,
-      1, 1, 0, 1, 3, 3, 4, 2, 2, 3, 2, 1, 0, 0, 2, 3, 0, 0, 3, 3, 2, 4, 2, 3, 0, 0,
-      4, 1, 3, 4, 2, 3, 4, 1, 0, 4, 2, 2, 3, 4, 0, 3, 3, 0, 0, 3, 3, 3, 2, 4, 2, 3,
-      2, 4, 4, 2, 4, 2, 3, 4, 1, 2, 3, 3, 1, 3, 3, 4, 3, 1, 3, 2, 4, 0, 0, 3, 3, 0,
-      1, 0, 4, 0, 0, 1, 4, 1, 3, 3, 1, 2, 1, 2, 2, 4, 1, 3, 3, 2, 0, 3, 4, 0, 0, 1,
-      1, 4, 2, 0, 4, 1, 1, 1, 0, 0, 4, 3, 3, 4, 0, 2, 4, 3, 1, 4, 2, 1, 3, 1, 1, 4,
-      3, 2, 1, 4, 4, 0, 0, 1, 0, 2, 3, 2, 1, 4, 3, 0, 2, 3, 3, 3, 2, 0, 3, 2, 1, 0,
-      0, 3, 1, 3, 1, 3, 2, 4, 1, 3, 3, 2, 3, 2, 2, 4, 1, 3, 3, 0, 4, 2, 2, 3, 4, 2,
-      3, 4, 3, 1, 2, 4, 0, 3, 3, 3, 0, 3, 3, 4, 3, 1, 4, 0, 1, 1, 0, 2, 1, 0, 4, 4,
-      4, 4, 1, 3, 0, 4, 4, 0, 2, 2, 4, 2, 1, 4, 3, 3, 1, 3, 0, 3, 4, 2, 0, 0, 0, 1,
-      3, 2, 1, 3, 3, 1, 3, 3, 2, 1, 2, 4, 4, 2, 0, 4, 2, 3, 3, 1, 3, 1, 4, 2, 0, 1,
-      2, 0, 4, 1, 0, 0, 4, 3, 4, 0, 4, 3, 4, 4, 4, 0, 0, 0, 3, 0, 0, 1, 2, 2, 4, 2,
-      4, 2, 0, 3, 1, 2, 3, 0, 1, 1, 3, 0, 0, 2, 4, 1, 4, 2, 1, 4, 0, 1, 3, 4, 0, 1,
-      1, 1, 1, 4, 2, 3, 4, 0, 1, 2, 1, 4, 2, 2, 1, 3, 4, 0, 2, 3, 1, 1, 1, 4, 1, 0,
-      2, 1, 4, 3, 0, 4, 0, 2, 1, 1, 4, 1, 0, 2, 2, 2, 2, 1, 4, 2]
+    epoch: 1000
+    validators:
+    - {activation_epoch: 271, exit_epoch: 1050, original_index: 0}
+    - {activation_epoch: 941, exit_epoch: 994, original_index: 1}
+    - {activation_epoch: 417, exit_epoch: 998, original_index: 2}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 3}
+    - {activation_epoch: 1062, exit_epoch: 1075, original_index: 4}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 5}
+    - {activation_epoch: 454, exit_epoch: 972, original_index: 6}
+    - {activation_epoch: 189, exit_epoch: 1017, original_index: 7}
+    - {activation_epoch: 278, exit_epoch: 1019, original_index: 8}
+    - {activation_epoch: 1063, exit_epoch: 18446744073709551615, original_index: 9}
+    - {activation_epoch: 1072, exit_epoch: 18446744073709551615, original_index: 10}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 11}
+    - {activation_epoch: 458, exit_epoch: 1027, original_index: 12}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 13}
+    - {activation_epoch: 968, exit_epoch: 3617, original_index: 14}
+    - {activation_epoch: 1037, exit_epoch: 1881, original_index: 15}
+    - {activation_epoch: 930, exit_epoch: 18446744073709551615, original_index: 16}
+    - {activation_epoch: 418, exit_epoch: 1019, original_index: 17}
+    - {activation_epoch: 1013, exit_epoch: 18446744073709551615, original_index: 18}
+    - {activation_epoch: 1021, exit_epoch: 18446744073709551615, original_index: 19}
+    - {activation_epoch: 537, exit_epoch: 989, original_index: 20}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 21}
+    - {activation_epoch: 148, exit_epoch: 970, original_index: 22}
+    - {activation_epoch: 685, exit_epoch: 924, original_index: 23}
+    - {activation_epoch: 968, exit_epoch: 18446744073709551615, original_index: 24}
+    - {activation_epoch: 919, exit_epoch: 957, original_index: 25}
+    - {activation_epoch: 971, exit_epoch: 18446744073709551615, original_index: 26}
+    - {activation_epoch: 959, exit_epoch: 18446744073709551615, original_index: 27}
+    - {activation_epoch: 715, exit_epoch: 935, original_index: 28}
+    - {activation_epoch: 966, exit_epoch: 3273, original_index: 29}
+    - {activation_epoch: 796, exit_epoch: 942, original_index: 30}
+    - {activation_epoch: 985, exit_epoch: 18446744073709551615, original_index: 31}
+    - {activation_epoch: 966, exit_epoch: 18446744073709551615, original_index: 32}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 33}
+    - {activation_epoch: 872, exit_epoch: 960, original_index: 34}
+    - {activation_epoch: 896, exit_epoch: 1018, original_index: 35}
+    - {activation_epoch: 750, exit_epoch: 954, original_index: 36}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 37}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 38}
+    - {activation_epoch: 996, exit_epoch: 4072, original_index: 39}
+    - {activation_epoch: 502, exit_epoch: 1011, original_index: 40}
+    - {activation_epoch: 236, exit_epoch: 1089, original_index: 41}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 42}
+    - {activation_epoch: 932, exit_epoch: 1002, original_index: 43}
+    - {activation_epoch: 263, exit_epoch: 975, original_index: 44}
+    - {activation_epoch: 1057, exit_epoch: 1299, original_index: 45}
+    - {activation_epoch: 514, exit_epoch: 1012, original_index: 46}
+    - {activation_epoch: 1032, exit_epoch: 1717, original_index: 47}
+    - {activation_epoch: 685, exit_epoch: 1003, original_index: 48}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 49}
+    - {activation_epoch: 905, exit_epoch: 1010, original_index: 50}
+    - {activation_epoch: 993, exit_epoch: 4859, original_index: 51}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 52}
+    - {activation_epoch: 451, exit_epoch: 1017, original_index: 53}
+    - {activation_epoch: 955, exit_epoch: 18446744073709551615, original_index: 54}
+    - {activation_epoch: 979, exit_epoch: 18446744073709551615, original_index: 55}
+    - {activation_epoch: 922, exit_epoch: 18446744073709551615, original_index: 56}
+    - {activation_epoch: 947, exit_epoch: 981, original_index: 57}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 58}
+    - {activation_epoch: 1005, exit_epoch: 1112, original_index: 59}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 60}
+    - {activation_epoch: 484, exit_epoch: 988, original_index: 61}
+    - {activation_epoch: 351, exit_epoch: 1016, original_index: 62}
+    - {activation_epoch: 534, exit_epoch: 1040, original_index: 63}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 64}
+    - {activation_epoch: 959, exit_epoch: 18446744073709551615, original_index: 65}
+    - {activation_epoch: 683, exit_epoch: 1000, original_index: 66}
+    - {activation_epoch: 189, exit_epoch: 994, original_index: 67}
+    - {activation_epoch: 810, exit_epoch: 1033, original_index: 68}
+    - {activation_epoch: 1024, exit_epoch: 18446744073709551615, original_index: 69}
+    - {activation_epoch: 648, exit_epoch: 1014, original_index: 70}
+    - {activation_epoch: 740, exit_epoch: 1064, original_index: 71}
+    - {activation_epoch: 827, exit_epoch: 986, original_index: 72}
+    - {activation_epoch: 1048, exit_epoch: 4305, original_index: 73}
+    - {activation_epoch: 358, exit_epoch: 976, original_index: 74}
+    - {activation_epoch: 1048, exit_epoch: 2229, original_index: 75}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 76}
+    - {activation_epoch: 718, exit_epoch: 982, original_index: 77}
+    - {activation_epoch: 1018, exit_epoch: 4914, original_index: 78}
+    - {activation_epoch: 164, exit_epoch: 1009, original_index: 79}
+    - {activation_epoch: 959, exit_epoch: 18446744073709551615, original_index: 80}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 81}
+    - {activation_epoch: 995, exit_epoch: 18446744073709551615, original_index: 82}
+    - {activation_epoch: 1015, exit_epoch: 3306, original_index: 83}
+    - {activation_epoch: 969, exit_epoch: 1037, original_index: 84}
+    - {activation_epoch: 1038, exit_epoch: 1770, original_index: 85}
+    - {activation_epoch: 1015, exit_epoch: 1455, original_index: 86}
+    - {activation_epoch: 1009, exit_epoch: 18446744073709551615, original_index: 87}
+    - {activation_epoch: 493, exit_epoch: 999, original_index: 88}
+    - {activation_epoch: 442, exit_epoch: 1095, original_index: 89}
+    - {activation_epoch: 286, exit_epoch: 1010, original_index: 90}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 91}
+    - {activation_epoch: 1061, exit_epoch: 3976, original_index: 92}
+    - {activation_epoch: 260, exit_epoch: 1023, original_index: 93}
+    - {activation_epoch: 101, exit_epoch: 1056, original_index: 94}
+    - {activation_epoch: 1010, exit_epoch: 3378, original_index: 95}
+    - {activation_epoch: 383, exit_epoch: 1017, original_index: 96}
+    - {activation_epoch: 1054, exit_epoch: 18446744073709551615, original_index: 97}
+    - {activation_epoch: 449, exit_epoch: 1009, original_index: 98}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 99}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 100}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 101}
+    - {activation_epoch: 763, exit_epoch: 987, original_index: 102}
+    - {activation_epoch: 967, exit_epoch: 1421, original_index: 103}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 104}
+    - {activation_epoch: 1032, exit_epoch: 1364, original_index: 105}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 106}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 107}
+    - {activation_epoch: 1044, exit_epoch: 1981, original_index: 108}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 109}
+    - {activation_epoch: 1044, exit_epoch: 18446744073709551615, original_index: 110}
+    - {activation_epoch: 300, exit_epoch: 1035, original_index: 111}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 112}
+    - {activation_epoch: 17, exit_epoch: 980, original_index: 113}
+    - {activation_epoch: 999, exit_epoch: 1878, original_index: 114}
+    - {activation_epoch: 447, exit_epoch: 1071, original_index: 115}
+    - {activation_epoch: 954, exit_epoch: 3746, original_index: 116}
+    - {activation_epoch: 1002, exit_epoch: 2199, original_index: 117}
+    - {activation_epoch: 956, exit_epoch: 3445, original_index: 118}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 119}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 120}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 121}
+    - {activation_epoch: 343, exit_epoch: 1017, original_index: 122}
+    - {activation_epoch: 957, exit_epoch: 992, original_index: 123}
+    - {activation_epoch: 23, exit_epoch: 996, original_index: 124}
+    - {activation_epoch: 944, exit_epoch: 18446744073709551615, original_index: 125}
+    - {activation_epoch: 537, exit_epoch: 963, original_index: 126}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 127}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 128}
+    - {activation_epoch: 1021, exit_epoch: 1047, original_index: 129}
+    - {activation_epoch: 553, exit_epoch: 949, original_index: 130}
+    - {activation_epoch: 93, exit_epoch: 994, original_index: 131}
+    - {activation_epoch: 999, exit_epoch: 2683, original_index: 132}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 133}
+    - {activation_epoch: 955, exit_epoch: 3183, original_index: 134}
+    - {activation_epoch: 337, exit_epoch: 1016, original_index: 135}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 136}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 137}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 138}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 139}
+    - {activation_epoch: 552, exit_epoch: 1048, original_index: 140}
+    - {activation_epoch: 229, exit_epoch: 972, original_index: 141}
+    - {activation_epoch: 1043, exit_epoch: 2371, original_index: 142}
+    - {activation_epoch: 948, exit_epoch: 2235, original_index: 143}
+    - {activation_epoch: 957, exit_epoch: 18446744073709551615, original_index: 144}
+    - {activation_epoch: 588, exit_epoch: 943, original_index: 145}
+    - {activation_epoch: 1005, exit_epoch: 2815, original_index: 146}
+    - {activation_epoch: 938, exit_epoch: 1052, original_index: 147}
+    - {activation_epoch: 1041, exit_epoch: 2010, original_index: 148}
+    - {activation_epoch: 1020, exit_epoch: 18446744073709551615, original_index: 149}
+    - {activation_epoch: 1000, exit_epoch: 18446744073709551615, original_index: 150}
+    - {activation_epoch: 1118, exit_epoch: 4632, original_index: 151}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 152}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 153}
+    - {activation_epoch: 955, exit_epoch: 971, original_index: 154}
+    - {activation_epoch: 704, exit_epoch: 964, original_index: 155}
+    - {activation_epoch: 586, exit_epoch: 909, original_index: 156}
+    - {activation_epoch: 985, exit_epoch: 1021, original_index: 157}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 158}
+    - {activation_epoch: 1025, exit_epoch: 3018, original_index: 159}
+    - {activation_epoch: 552, exit_epoch: 1024, original_index: 160}
+    - {activation_epoch: 744, exit_epoch: 990, original_index: 161}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 162}
+    - {activation_epoch: 755, exit_epoch: 979, original_index: 163}
+    - {activation_epoch: 928, exit_epoch: 986, original_index: 164}
+    - {activation_epoch: 864, exit_epoch: 1006, original_index: 165}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 166}
+    - {activation_epoch: 1026, exit_epoch: 18446744073709551615, original_index: 167}
+    - {activation_epoch: 1044, exit_epoch: 2046, original_index: 168}
+    - {activation_epoch: 468, exit_epoch: 982, original_index: 169}
+    - {activation_epoch: 1023, exit_epoch: 4408, original_index: 170}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 171}
+    - {activation_epoch: 961, exit_epoch: 18446744073709551615, original_index: 172}
+    - {activation_epoch: 262, exit_epoch: 994, original_index: 173}
+    - {activation_epoch: 261, exit_epoch: 1019, original_index: 174}
+    - {activation_epoch: 920, exit_epoch: 1040, original_index: 175}
+    - {activation_epoch: 983, exit_epoch: 1500, original_index: 176}
+    - {activation_epoch: 1038, exit_epoch: 4647, original_index: 177}
+    - {activation_epoch: 558, exit_epoch: 980, original_index: 178}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 179}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 180}
+    - {activation_epoch: 729, exit_epoch: 969, original_index: 181}
+    - {activation_epoch: 999, exit_epoch: 1686, original_index: 182}
+    - {activation_epoch: 946, exit_epoch: 18446744073709551615, original_index: 183}
+    - {activation_epoch: 294, exit_epoch: 988, original_index: 184}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 185}
+    - {activation_epoch: 726, exit_epoch: 973, original_index: 186}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 187}
+    - {activation_epoch: 982, exit_epoch: 18446744073709551615, original_index: 188}
+    - {activation_epoch: 1003, exit_epoch: 18446744073709551615, original_index: 189}
+    - {activation_epoch: 426, exit_epoch: 969, original_index: 190}
+    - {activation_epoch: 1005, exit_epoch: 1494, original_index: 191}
+    - {activation_epoch: 963, exit_epoch: 18446744073709551615, original_index: 192}
+    - {activation_epoch: 1056, exit_epoch: 18446744073709551615, original_index: 193}
+    - {activation_epoch: 980, exit_epoch: 18446744073709551615, original_index: 194}
+    - {activation_epoch: 991, exit_epoch: 1028, original_index: 195}
+    - {activation_epoch: 395, exit_epoch: 1069, original_index: 196}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 197}
+    - {activation_epoch: 961, exit_epoch: 1406, original_index: 198}
+    - {activation_epoch: 977, exit_epoch: 3947, original_index: 199}
+    - {activation_epoch: 812, exit_epoch: 997, original_index: 200}
+    - {activation_epoch: 399, exit_epoch: 948, original_index: 201}
+    - {activation_epoch: 921, exit_epoch: 944, original_index: 202}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 203}
+    - {activation_epoch: 425, exit_epoch: 993, original_index: 204}
+    - {activation_epoch: 1076, exit_epoch: 4378, original_index: 205}
+    - {activation_epoch: 912, exit_epoch: 1005, original_index: 206}
+    - {activation_epoch: 1007, exit_epoch: 2567, original_index: 207}
+    - {activation_epoch: 1068, exit_epoch: 18446744073709551615, original_index: 208}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 209}
+    - {activation_epoch: 408, exit_epoch: 993, original_index: 210}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 211}
+    - {activation_epoch: 971, exit_epoch: 2084, original_index: 212}
+    - {activation_epoch: 1043, exit_epoch: 18446744073709551615, original_index: 213}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 214}
+    - {activation_epoch: 631, exit_epoch: 991, original_index: 215}
+    - {activation_epoch: 982, exit_epoch: 4995, original_index: 216}
+    - {activation_epoch: 990, exit_epoch: 2756, original_index: 217}
+    - {activation_epoch: 592, exit_epoch: 959, original_index: 218}
+    - {activation_epoch: 207, exit_epoch: 1029, original_index: 219}
+    - {activation_epoch: 127, exit_epoch: 1038, original_index: 220}
+    - {activation_epoch: 1045, exit_epoch: 18446744073709551615, original_index: 221}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 222}
+    - {activation_epoch: 875, exit_epoch: 1004, original_index: 223}
+    - {activation_epoch: 31, exit_epoch: 1022, original_index: 224}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 225}
+    - {activation_epoch: 1053, exit_epoch: 18446744073709551615, original_index: 226}
+    - {activation_epoch: 1042, exit_epoch: 18446744073709551615, original_index: 227}
+    - {activation_epoch: 1007, exit_epoch: 18446744073709551615, original_index: 228}
+    - {activation_epoch: 244, exit_epoch: 980, original_index: 229}
+    - {activation_epoch: 972, exit_epoch: 2489, original_index: 230}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 231}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 232}
+    - {activation_epoch: 1041, exit_epoch: 3683, original_index: 233}
+    - {activation_epoch: 134, exit_epoch: 1006, original_index: 234}
+    - {activation_epoch: 1027, exit_epoch: 18446744073709551615, original_index: 235}
+    - {activation_epoch: 1053, exit_epoch: 18446744073709551615, original_index: 236}
+    - {activation_epoch: 964, exit_epoch: 18446744073709551615, original_index: 237}
+    - {activation_epoch: 979, exit_epoch: 4538, original_index: 238}
+    - {activation_epoch: 83, exit_epoch: 1054, original_index: 239}
+    - {activation_epoch: 1017, exit_epoch: 2421, original_index: 240}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 241}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 242}
+    - {activation_epoch: 412, exit_epoch: 986, original_index: 243}
+    - {activation_epoch: 966, exit_epoch: 18446744073709551615, original_index: 244}
+    - {activation_epoch: 959, exit_epoch: 18446744073709551615, original_index: 245}
+    - {activation_epoch: 957, exit_epoch: 18446744073709551615, original_index: 246}
+    - {activation_epoch: 1056, exit_epoch: 1067, original_index: 247}
+    - {activation_epoch: 903, exit_epoch: 1021, original_index: 248}
+    - {activation_epoch: 943, exit_epoch: 4523, original_index: 249}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 250}
+    - {activation_epoch: 1010, exit_epoch: 4032, original_index: 251}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 252}
+    - {activation_epoch: 994, exit_epoch: 18446744073709551615, original_index: 253}
+    - {activation_epoch: 1040, exit_epoch: 4040, original_index: 254}
+    - {activation_epoch: 826, exit_epoch: 963, original_index: 255}
+    - {activation_epoch: 977, exit_epoch: 2132, original_index: 256}
+    - {activation_epoch: 641, exit_epoch: 961, original_index: 257}
+    - {activation_epoch: 1041, exit_epoch: 18446744073709551615, original_index: 258}
+    - {activation_epoch: 631, exit_epoch: 1032, original_index: 259}
+    - {activation_epoch: 1001, exit_epoch: 18446744073709551615, original_index: 260}
+    - {activation_epoch: 954, exit_epoch: 1037, original_index: 261}
+    - {activation_epoch: 1036, exit_epoch: 18446744073709551615, original_index: 262}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 263}
+    - {activation_epoch: 171, exit_epoch: 965, original_index: 264}
+    - {activation_epoch: 801, exit_epoch: 1001, original_index: 265}
+    - {activation_epoch: 978, exit_epoch: 2148, original_index: 266}
+    - {activation_epoch: 105, exit_epoch: 1024, original_index: 267}
+    - {activation_epoch: 1057, exit_epoch: 4696, original_index: 268}
+    - {activation_epoch: 544, exit_epoch: 988, original_index: 269}
+    - {activation_epoch: 934, exit_epoch: 1914, original_index: 270}
+    - {activation_epoch: 1006, exit_epoch: 1299, original_index: 271}
+    - {activation_epoch: 1024, exit_epoch: 3671, original_index: 272}
+    - {activation_epoch: 646, exit_epoch: 959, original_index: 273}
+    - {activation_epoch: 951, exit_epoch: 18446744073709551615, original_index: 274}
+    - {activation_epoch: 1054, exit_epoch: 4221, original_index: 275}
+    - {activation_epoch: 571, exit_epoch: 959, original_index: 276}
+    - {activation_epoch: 829, exit_epoch: 1011, original_index: 277}
+    - {activation_epoch: 755, exit_epoch: 1029, original_index: 278}
+    - {activation_epoch: 1042, exit_epoch: 2187, original_index: 279}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 280}
+    - {activation_epoch: 1012, exit_epoch: 1055, original_index: 281}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 282}
+    - {activation_epoch: 469, exit_epoch: 987, original_index: 283}
+    - {activation_epoch: 20, exit_epoch: 1036, original_index: 284}
+    - {activation_epoch: 200, exit_epoch: 1003, original_index: 285}
+    - {activation_epoch: 912, exit_epoch: 2504, original_index: 286}
+    - {activation_epoch: 80, exit_epoch: 966, original_index: 287}
+    - {activation_epoch: 1046, exit_epoch: 18446744073709551615, original_index: 288}
+    - {activation_epoch: 226, exit_epoch: 951, original_index: 289}
+    - {activation_epoch: 935, exit_epoch: 2904, original_index: 290}
+    - {activation_epoch: 130, exit_epoch: 984, original_index: 291}
+    - {activation_epoch: 524, exit_epoch: 1084, original_index: 292}
+    - {activation_epoch: 537, exit_epoch: 1049, original_index: 293}
+    - {activation_epoch: 270, exit_epoch: 979, original_index: 294}
+    - {activation_epoch: 1021, exit_epoch: 1165, original_index: 295}
+    - {activation_epoch: 729, exit_epoch: 955, original_index: 296}
+    - {activation_epoch: 1028, exit_epoch: 18446744073709551615, original_index: 297}
+    - {activation_epoch: 985, exit_epoch: 18446744073709551615, original_index: 298}
+    - {activation_epoch: 276, exit_epoch: 992, original_index: 299}
+    - {activation_epoch: 899, exit_epoch: 989, original_index: 300}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 301}
+    - {activation_epoch: 488, exit_epoch: 1069, original_index: 302}
+    - {activation_epoch: 723, exit_epoch: 1005, original_index: 303}
+    - {activation_epoch: 453, exit_epoch: 970, original_index: 304}
+    - {activation_epoch: 1009, exit_epoch: 3191, original_index: 305}
+    - {activation_epoch: 992, exit_epoch: 4896, original_index: 306}
+    - {activation_epoch: 956, exit_epoch: 3087, original_index: 307}
+    - {activation_epoch: 514, exit_epoch: 1006, original_index: 308}
+    - {activation_epoch: 993, exit_epoch: 1527, original_index: 309}
+    - {activation_epoch: 1005, exit_epoch: 1223, original_index: 310}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 311}
+    - {activation_epoch: 680, exit_epoch: 965, original_index: 312}
+    - {activation_epoch: 963, exit_epoch: 18446744073709551615, original_index: 313}
+    - {activation_epoch: 1052, exit_epoch: 3183, original_index: 314}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 315}
+    - {activation_epoch: 765, exit_epoch: 992, original_index: 316}
+    - {activation_epoch: 380, exit_epoch: 1025, original_index: 317}
+    - {activation_epoch: 240, exit_epoch: 973, original_index: 318}
+    - {activation_epoch: 635, exit_epoch: 955, original_index: 319}
+    - {activation_epoch: 8, exit_epoch: 989, original_index: 320}
+    - {activation_epoch: 986, exit_epoch: 3029, original_index: 321}
+    - {activation_epoch: 168, exit_epoch: 953, original_index: 322}
+    - {activation_epoch: 451, exit_epoch: 1004, original_index: 323}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 324}
+    - {activation_epoch: 961, exit_epoch: 18446744073709551615, original_index: 325}
+    - {activation_epoch: 992, exit_epoch: 18446744073709551615, original_index: 326}
+    - {activation_epoch: 1050, exit_epoch: 18446744073709551615, original_index: 327}
+    - {activation_epoch: 986, exit_epoch: 18446744073709551615, original_index: 328}
+    - {activation_epoch: 1046, exit_epoch: 2387, original_index: 329}
+    - {activation_epoch: 279, exit_epoch: 1082, original_index: 330}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 331}
+    - {activation_epoch: 983, exit_epoch: 3474, original_index: 332}
+    - {activation_epoch: 107, exit_epoch: 1066, original_index: 333}
+    - {activation_epoch: 88, exit_epoch: 955, original_index: 334}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 335}
+    - {activation_epoch: 1047, exit_epoch: 4677, original_index: 336}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 337}
+    - {activation_epoch: 921, exit_epoch: 995, original_index: 338}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 339}
+    - {activation_epoch: 1006, exit_epoch: 2799, original_index: 340}
+    - {activation_epoch: 891, exit_epoch: 1044, original_index: 341}
+    - {activation_epoch: 993, exit_epoch: 18446744073709551615, original_index: 342}
+    - {activation_epoch: 1002, exit_epoch: 4000, original_index: 343}
+    - {activation_epoch: 1004, exit_epoch: 18446744073709551615, original_index: 344}
+    - {activation_epoch: 819, exit_epoch: 1022, original_index: 345}
+    - {activation_epoch: 103, exit_epoch: 1047, original_index: 346}
+    - {activation_epoch: 975, exit_epoch: 18446744073709551615, original_index: 347}
+    - {activation_epoch: 1008, exit_epoch: 3763, original_index: 348}
+    - {activation_epoch: 965, exit_epoch: 18446744073709551615, original_index: 349}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 350}
+    - {activation_epoch: 204, exit_epoch: 1044, original_index: 351}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 352}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 353}
+    - {activation_epoch: 1003, exit_epoch: 3183, original_index: 354}
+    - {activation_epoch: 949, exit_epoch: 18446744073709551615, original_index: 355}
+    - {activation_epoch: 998, exit_epoch: 18446744073709551615, original_index: 356}
+    - {activation_epoch: 1031, exit_epoch: 18446744073709551615, original_index: 357}
+    - {activation_epoch: 897, exit_epoch: 1021, original_index: 358}
+    - {activation_epoch: 999, exit_epoch: 1259, original_index: 359}
+    - {activation_epoch: 348, exit_epoch: 977, original_index: 360}
+    - {activation_epoch: 992, exit_epoch: 1034, original_index: 361}
+    - {activation_epoch: 342, exit_epoch: 988, original_index: 362}
+    - {activation_epoch: 385, exit_epoch: 943, original_index: 363}
+    - {activation_epoch: 1, exit_epoch: 931, original_index: 364}
+    - {activation_epoch: 825, exit_epoch: 976, original_index: 365}
+    - {activation_epoch: 340, exit_epoch: 1019, original_index: 366}
+    - {activation_epoch: 432, exit_epoch: 979, original_index: 367}
+    - {activation_epoch: 75, exit_epoch: 1002, original_index: 368}
+    - {activation_epoch: 1001, exit_epoch: 4444, original_index: 369}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 370}
+    - {activation_epoch: 977, exit_epoch: 18446744073709551615, original_index: 371}
+    - {activation_epoch: 77, exit_epoch: 963, original_index: 372}
+    - {activation_epoch: 997, exit_epoch: 1025, original_index: 373}
+    - {activation_epoch: 971, exit_epoch: 18446744073709551615, original_index: 374}
+    - {activation_epoch: 1037, exit_epoch: 4452, original_index: 375}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 376}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 377}
+    - {activation_epoch: 963, exit_epoch: 18446744073709551615, original_index: 378}
+    - {activation_epoch: 370, exit_epoch: 998, original_index: 379}
+    - {activation_epoch: 994, exit_epoch: 2375, original_index: 380}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 381}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 382}
+    - {activation_epoch: 1065, exit_epoch: 4571, original_index: 383}
+    - {activation_epoch: 1069, exit_epoch: 1970, original_index: 384}
+    - {activation_epoch: 503, exit_epoch: 1012, original_index: 385}
+    - {activation_epoch: 1044, exit_epoch: 2724, original_index: 386}
+    - {activation_epoch: 395, exit_epoch: 987, original_index: 387}
+    - {activation_epoch: 939, exit_epoch: 18446744073709551615, original_index: 388}
+    - {activation_epoch: 1000, exit_epoch: 3118, original_index: 389}
+    - {activation_epoch: 930, exit_epoch: 975, original_index: 390}
+    - {activation_epoch: 801, exit_epoch: 939, original_index: 391}
+    - {activation_epoch: 809, exit_epoch: 1028, original_index: 392}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 393}
+    - {activation_epoch: 896, exit_epoch: 1030, original_index: 394}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 395}
+    - {activation_epoch: 1045, exit_epoch: 18446744073709551615, original_index: 396}
+    - {activation_epoch: 346, exit_epoch: 1035, original_index: 397}
+    - {activation_epoch: 1021, exit_epoch: 2207, original_index: 398}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 399}
+    - {activation_epoch: 568, exit_epoch: 1012, original_index: 400}
+    - {activation_epoch: 822, exit_epoch: 936, original_index: 401}
+    - {activation_epoch: 951, exit_epoch: 1679, original_index: 402}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 403}
+    - {activation_epoch: 1020, exit_epoch: 1661, original_index: 404}
+    - {activation_epoch: 609, exit_epoch: 983, original_index: 405}
+    - {activation_epoch: 821, exit_epoch: 1007, original_index: 406}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 407}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 408}
+    - {activation_epoch: 340, exit_epoch: 949, original_index: 409}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 410}
+    - {activation_epoch: 403, exit_epoch: 1033, original_index: 411}
+    - {activation_epoch: 586, exit_epoch: 979, original_index: 412}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 413}
+    - {activation_epoch: 1062, exit_epoch: 3722, original_index: 414}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 415}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 416}
+    - {activation_epoch: 1017, exit_epoch: 3098, original_index: 417}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 418}
+    - {activation_epoch: 940, exit_epoch: 18446744073709551615, original_index: 419}
+    - {activation_epoch: 1063, exit_epoch: 18446744073709551615, original_index: 420}
+    - {activation_epoch: 284, exit_epoch: 994, original_index: 421}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 422}
+    - {activation_epoch: 1005, exit_epoch: 18446744073709551615, original_index: 423}
+    - {activation_epoch: 131, exit_epoch: 1055, original_index: 424}
+    - {activation_epoch: 829, exit_epoch: 954, original_index: 425}
+    - {activation_epoch: 825, exit_epoch: 917, original_index: 426}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 427}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 428}
+    - {activation_epoch: 674, exit_epoch: 985, original_index: 429}
+    - {activation_epoch: 1012, exit_epoch: 18446744073709551615, original_index: 430}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 431}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 432}
+    - {activation_epoch: 376, exit_epoch: 956, original_index: 433}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 434}
+    - {activation_epoch: 90, exit_epoch: 1039, original_index: 435}
+    - {activation_epoch: 993, exit_epoch: 18446744073709551615, original_index: 436}
+    - {activation_epoch: 174, exit_epoch: 1026, original_index: 437}
+    - {activation_epoch: 158, exit_epoch: 937, original_index: 438}
+    - {activation_epoch: 274, exit_epoch: 1030, original_index: 439}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 440}
+    - {activation_epoch: 993, exit_epoch: 18446744073709551615, original_index: 441}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 442}
+    - {activation_epoch: 1006, exit_epoch: 18446744073709551615, original_index: 443}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 444}
+    - {activation_epoch: 993, exit_epoch: 2028, original_index: 445}
+    - {activation_epoch: 1052, exit_epoch: 18446744073709551615, original_index: 446}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 447}
+    - {activation_epoch: 941, exit_epoch: 1010, original_index: 448}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 449}
+    - {activation_epoch: 1013, exit_epoch: 1855, original_index: 450}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 451}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 452}
+    - {activation_epoch: 1050, exit_epoch: 4706, original_index: 453}
+    - {activation_epoch: 1017, exit_epoch: 1044, original_index: 454}
+    - {activation_epoch: 742, exit_epoch: 1050, original_index: 455}
+    - {activation_epoch: 951, exit_epoch: 999, original_index: 456}
+    - {activation_epoch: 1002, exit_epoch: 1977, original_index: 457}
+    - {activation_epoch: 1030, exit_epoch: 1616, original_index: 458}
+    - {activation_epoch: 989, exit_epoch: 18446744073709551615, original_index: 459}
+    - {activation_epoch: 640, exit_epoch: 993, original_index: 460}
+    - {activation_epoch: 1010, exit_epoch: 18446744073709551615, original_index: 461}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 462}
+    - {activation_epoch: 457, exit_epoch: 957, original_index: 463}
+    - {activation_epoch: 1016, exit_epoch: 18446744073709551615, original_index: 464}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 465}
+    - {activation_epoch: 985, exit_epoch: 1006, original_index: 466}
+    - {activation_epoch: 956, exit_epoch: 1790, original_index: 467}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 468}
+    - {activation_epoch: 946, exit_epoch: 2225, original_index: 469}
+    - {activation_epoch: 1032, exit_epoch: 18446744073709551615, original_index: 470}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 471}
+    - {activation_epoch: 18446744073709551615, exit_epoch: 18446744073709551615, original_index: 472}
+    - {activation_epoch: 975, exit_epoch: 2891, original_index: 473}
+    - {activation_epoch: 277, exit_epoch: 995, original_index: 474}
+    - {activation_epoch: 946, exit_epoch: 18446744073709551615, original_index: 475}
   output:
-  - - committee: [350, 75]
-      shard: 986
-      total_validator_count: 145
-  - - committee: [77, 255]
-      shard: 987
-      total_validator_count: 145
-  - - committee: [129, 280]
-      shard: 988
-      total_validator_count: 145
-  - - committee: [70, 162, 249]
-      shard: 989
-      total_validator_count: 145
-  - - committee: [47, 374]
-      shard: 990
-      total_validator_count: 145
-  - - committee: [237, 148]
-      shard: 991
-      total_validator_count: 145
-  - - committee: [365, 311]
-      shard: 992
-      total_validator_count: 145
-  - - committee: [369, 352, 263]
-      shard: 993
-      total_validator_count: 145
-  - - committee: [331, 192]
-      shard: 994
-      total_validator_count: 145
-  - - committee: [10, 20]
-      shard: 995
-      total_validator_count: 145
-  - - committee: [144, 42]
-      shard: 996
-      total_validator_count: 145
-  - - committee: [367, 314, 114]
-      shard: 997
-      total_validator_count: 145
-  - - committee: [327, 68]
-      shard: 998
-      total_validator_count: 145
-  - - committee: [371, 147]
-      shard: 999
-      total_validator_count: 145
-  - - committee: [324, 340]
-      shard: 1000
-      total_validator_count: 145
-  - - committee: [344, 98, 341]
-      shard: 1001
-      total_validator_count: 145
-  - - committee: [253, 270]
-      shard: 1002
-      total_validator_count: 145
-  - - committee: [161, 223]
-      shard: 1003
-      total_validator_count: 145
-  - - committee: [40, 105, 305]
-      shard: 1004
-      total_validator_count: 145
-  - - committee: [230, 190]
-      shard: 1005
-      total_validator_count: 145
-  - - committee: [112, 336]
-      shard: 1006
-      total_validator_count: 145
-  - - committee: [184, 345]
-      shard: 1007
-      total_validator_count: 145
-  - - committee: [2, 50, 264]
-      shard: 1008
-      total_validator_count: 145
-  - - committee: [111, 239]
-      shard: 1009
-      total_validator_count: 145
-  - - committee: [321, 198]
-      shard: 1010
-      total_validator_count: 145
-  - - committee: [91, 174]
-      shard: 1011
-      total_validator_count: 145
-  - - committee: [157, 220, 353]
-      shard: 1012
-      total_validator_count: 145
-  - - committee: [178, 303]
-      shard: 1013
-      total_validator_count: 145
-  - - committee: [173, 283]
-      shard: 1014
-      total_validator_count: 145
-  - - committee: [21, 373]
-      shard: 1015
-      total_validator_count: 145
-  - - committee: [205, 57, 109]
-      shard: 1016
-      total_validator_count: 145
-  - - committee: [332, 27]
-      shard: 1017
-      total_validator_count: 145
-  - - committee: [17, 170]
-      shard: 1018
-      total_validator_count: 145
-  - - committee: [145, 267, 182]
-      shard: 1019
-      total_validator_count: 145
-  - - committee: [301, 80]
-      shard: 1020
-      total_validator_count: 145
-  - - committee: [221, 23]
-      shard: 1021
-      total_validator_count: 145
-  - - committee: [72, 366]
-      shard: 1022
-      total_validator_count: 145
-  - - committee: [187, 126, 197]
-      shard: 1023
-      total_validator_count: 145
-  - - committee: [139, 84]
-      shard: 0
-      total_validator_count: 145
-  - - committee: [372, 30]
-      shard: 1
-      total_validator_count: 145
-  - - committee: [342, 56]
-      shard: 2
-      total_validator_count: 145
-  - - committee: [142, 275, 356]
-      shard: 3
-      total_validator_count: 145
-  - - committee: [279, 81]
-      shard: 4
-      total_validator_count: 145
-  - - committee: [151, 334]
-      shard: 5
-      total_validator_count: 145
-  - - committee: [217, 244]
-      shard: 6
-      total_validator_count: 145
-  - - committee: [315, 108, 323]
-      shard: 7
-      total_validator_count: 145
-  - - committee: [206, 302]
-      shard: 8
-      total_validator_count: 145
-  - - committee: [152, 130]
-      shard: 9
-      total_validator_count: 145
-  - - committee: [319, 256, 377]
-      shard: 10
-      total_validator_count: 145
-  - - committee: [333, 110]
-      shard: 11
-      total_validator_count: 145
-  - - committee: [273, 103]
-      shard: 12
-      total_validator_count: 145
-  - - committee: [89, 259]
-      shard: 13
-      total_validator_count: 145
-  - - committee: [180, 236, 117]
-      shard: 14
-      total_validator_count: 145
-  - - committee: [354, 53]
-      shard: 15
-      total_validator_count: 145
-  - - committee: [262, 131]
-      shard: 16
-      total_validator_count: 145
-  - - committee: [16, 124]
-      shard: 17
-      total_validator_count: 145
-  - - committee: [358, 240, 375]
-      shard: 18
-      total_validator_count: 145
-  - - committee: [310, 307]
-      shard: 19
-      total_validator_count: 145
-  - - committee: [123, 3]
-      shard: 20
-      total_validator_count: 145
-  - - committee: [201, 34]
-      shard: 21
-      total_validator_count: 145
-  - - committee: [166, 224, 277]
-      shard: 22
-      total_validator_count: 145
-  - - committee: [189, 31]
-      shard: 23
-      total_validator_count: 145
-  - - committee: [159, 359]
-      shard: 24
-      total_validator_count: 145
-  - - committee: [13, 28, 346]
-      shard: 25
-      total_validator_count: 145
-  seed: '0xfe331725ea135ef16c8289d503c6c653938ba23e88ca435dbba2e8733402898c'
+  - [394, 473]
+  - [51, 71, 245]
+  - [459, 196, 62]
+  - [223, 132, 116]
+  - [80, 192]
+  - [40, 35, 172]
+  - [323, 65, 278]
+  - [89, 345, 0]
+  - [341, 455]
+  - [301, 216, 212]
+  - [26, 143, 270]
+  - [27, 368, 448]
+  - [355, 266]
+  - [219, 3, 43]
+  - [466, 346, 325]
+  - [437, 176, 111]
+  - [41, 246, 286]
+  - [182, 475]
+  - [220, 103, 385]
+  - [342, 118, 435]
+  - [160, 406, 249]
+  - [351, 224]
+  - [14, 411, 165]
+  - [82, 98, 274]
+  - [114, 84, 373]
+  - [56, 96]
+  - [135, 230, 46]
+  - [389, 147, 122]
+  - [439, 48, 17]
+  - [321, 55]
+  - [188, 175, 293]
+  - [374, 140, 298]
+  - [359, 436, 267]
+  - [29, 174, 237]
+  - [277, 309]
+  - [76, 79, 356]
+  - [16, 328, 290]
+  - [313, 358, 50]
+  - [397, 244]
+  - [347, 445, 378]
+  - [31, 99, 353]
+  - [63, 183, 125]
+  - [39, 206]
+  - [24, 392, 306]
+  - [265, 361, 90]
+  - [284, 248, 259]
+  - [285, 349]
+  - [292, 93, 402]
+  - [198, 194, 419]
+  - [302, 53, 54]
+  - [68, 144, 150]
+  - [366, 400]
+  - [388, 380, 238]
+  - [467, 94, 441]
+  - [303, 8, 239]
+  - [261, 326]
+  - [234, 307, 308]
+  - [332, 115, 469]
+  - [231, 217, 330]
+  - [7, 253]
+  - [333, 157, 256]
+  - [199, 195, 32]
+  - [12, 317, 424]
+  - [134, 70, 371]
+  seed: '0x5c27019e6b8ee271db4ad9cd6e2c13e23f2663ec55ceb96e5d27ab376794fda9'


### PR DESCRIPTION
# Update validator shuffling
This PR updates and improves validator shuffling generation.

This most likely needs some polishing. There's a couple things I'm not happy
with yet:
* [x] The new epoch choice is too big - and therefore surrounded only by
  the active validators who didn't leave the set yet (no "soon-to-leaves" useful
  for delay edge case testing)
* [x] I did not consider the delays outlined by the spec

## Original commit message (may change as I squash new things into it):

Update test vec generation and make it dynamic

This commit updates the validator shuffling generator and tries to make
the test validator sets more life-like.

constants.py:
* Add FAR_FUTURE_EPOCH

core_helpers.py:
* Update the helpers needed for validator shuffling

Remove enums.py: status flags are not used since 2018-12-28

tgen_shuffling.py:
* Use a randomized probabilistic approach for generating configurably
diverse validator sets; pre-FAR_FUTURE_EPOCH exit epochs truncated for
readability
* Change the YAML layout to include validator data needed for
present-day shuffling

yaml_objects.py:
* Change ValidatorRecord name to Validator (as in spec); change fields
for up-to-date shuffling
* Remove ShardCommittee (not used for shuffling at all as of today)

test_vector_shuffling.yml:
* Regenerate